### PR TITLE
Bump version to .dev

### DIFF
--- a/pycrostates/_version.py
+++ b/pycrostates/_version.py
@@ -1,3 +1,3 @@
 """Version number."""
 
-__version__ = '0.1.0'
+__version__ = '0.1.0.dev'

--- a/pycrostates/cluster/_base.py
+++ b/pycrostates/cluster/_base.py
@@ -491,11 +491,8 @@ class _BaseCluster(ABC):
         std[std == 0] = 1  # std == 0 -> null map
         data /= std
 
-        # TODO: Remove transpose and change axis
-        states = states.T
-        states -= np.mean(states, axis=0)
-        states /= np.std(states, axis=0)
-        states = states.T
+        states -= np.mean(states, axis=1)[:, np.newaxis]
+        states /= np.std(states, axis=1)[:, np.newaxis]
 
         labels = np.argmax(np.abs(np.dot(states, data)), axis=0)
 

--- a/pycrostates/cluster/_base.py
+++ b/pycrostates/cluster/_base.py
@@ -160,7 +160,6 @@ class _BaseCluster(ABC):
         new_names : list | tuple
             1D iterable containing the new cluster names.
         """
-        # TODO: Add support for mapping to be a callable function (str -> str)
         self._check_fit()
 
         if mapping is not None and new_names is not None:
@@ -519,7 +518,6 @@ class _BaseCluster(ABC):
             IEEE Transactions on Biomedical Engineering,
             vol. 42, no. 7, pp. 658-665, July 1995,
             https://doi.org/10.1109/10.391164."""
-        # TODO: Check the smooting equations
         Ne, Nt = data.shape
         Nu = states.shape[0]
         Vvar = np.sum(data * data, axis=0)


### PR DESCRIPTION
After a release, the version number should be bumped (minor or major depending on the next release) + `.dev` should be added at the end. This way, there is no confusion between a release version and a version installed from GitHub repository.

There is probably a convention about this, and this is just a method similar to the one used by MNE.

```
>>> version x.x.x.dev
>>> Remove .dev
>>> Build and release
>>> Bump version to x.x+1.x.dev
```