### PR TITLE
Add note for `mne.io.read_raw_eeglab` calls requiring `pymatreader`

### DIFF
--- a/pycrostates/datasets/lemon/lemon.py
+++ b/pycrostates/datasets/lemon/lemon.py
@@ -54,8 +54,10 @@ def data_path(subject_id: str, condition: str) -> Path:
     :func:`mne.io.read_raw_eeglab`, the ``pymatreader`` optional dependency
     is required. Use the following installation method appropriate for your
     environment:
-    - ``pip install pymatreader```
-    - ``conda install -c conda-forge pymatreader```
+
+    - ``pip install pymatreader``
+    - ``conda install -c conda-forge pymatreader``
+
     Note that an environment created via the MNE installers includes
     ``pymatreader`` by default.
     """  # noqa: E501

--- a/pycrostates/datasets/lemon/lemon.py
+++ b/pycrostates/datasets/lemon/lemon.py
@@ -17,11 +17,11 @@ from ...utils._config import get_config
 
 
 def data_path(subject_id: str, condition: str) -> Path:
-    """Get path to local copy of preprocessed EEG recording from the LEMON dataset.
+    """Get path to a local copy of preprocessed EEG recording from the LEMON dataset.
 
-    Get path to local copy of preprocessed EEG recording from the
+    Get path to a local copy of preprocessed EEG recording from the
     mind-brain-body dataset of MRI, EEG, cognition, emotion, and peripheral
-    physiology in young and old adults dataset files.
+    physiology in young and old adults.
     If there is no local copy of the recording, this function will fetch it
     from the online repository and store it. The default location is
     ``~/pycrostates_data``.
@@ -47,6 +47,17 @@ def data_path(subject_id: str, condition: str) -> Path:
            A mind-brain-body dataset of MRI, EEG, cognition, emotion,
            and peripheral physiology in young and old adults. Sci Data 6, 180308 (2019).
            https://doi.org/10.1038/sdata.2018.308
+
+    Notes
+    -----
+    The lemon datasets is composed of EEGLAB files. To use the MNE reader
+    :func:`mne.io.read_raw_eeglab`, the ``pymatreader`` optional dependency
+    is required. Use the following installation method appropriate for your
+    environment:
+    - ``pip install pymatreader```
+    - ``conda install -c conda-forge pymatreader```
+    Note that an environment created via the MNE installers includes
+    ``pymatreader`` by default.
     """  # noqa: E501
     _check_type(subject_id, (str,), "subject_id")
     _check_type(condition, (str,), "condition")

--- a/tutorials/clustering/plot_modK.py
+++ b/tutorials/clustering/plot_modK.py
@@ -6,6 +6,18 @@ This tutorial introduces the :class:`pycrostates.clustering.ModKMeans`
 structure in detail.
 """
 
+#%%
+# .. note::
+#
+#     The lemon datasets is composed of EEGLAB files. To use the MNE reader
+#     :func:`mne.io.read_raw_eeglab`, the ``pymatreader`` optional dependency
+#     is required. Use the following installation method appropriate for your
+#     environment:
+#     - ``pip install pymatreader```
+#     - ``conda install -c conda-forge pymatreader```
+#     Note that an environment created via the MNE installers includes
+#     ``pymatreader`` by default.
+
 from mne.io import read_raw_eeglab
 
 from pycrostates.cluster import ModKMeans

--- a/tutorials/clustering/plot_modK.py
+++ b/tutorials/clustering/plot_modK.py
@@ -13,8 +13,10 @@ structure in detail.
 #     :func:`mne.io.read_raw_eeglab`, the ``pymatreader`` optional dependency
 #     is required. Use the following installation method appropriate for your
 #     environment:
-#     - ``pip install pymatreader```
-#     - ``conda install -c conda-forge pymatreader```
+#
+#     - ``pip install pymatreader``
+#     - ``conda install -c conda-forge pymatreader``
+#
 #     Note that an environment created via the MNE installers includes
 #     ``pymatreader`` by default.
 

--- a/tutorials/group_level_analysis/plot_group_level_with_individual_clusters.py
+++ b/tutorials/group_level_analysis/plot_group_level_with_individual_clusters.py
@@ -7,7 +7,16 @@ by computing group-level topographies based on individual clusters.
 """
 
 #%%
-# We first start by importing some EEG data
+# .. note::
+#
+#     The lemon datasets is composed of EEGLAB files. To use the MNE reader
+#     :func:`mne.io.read_raw_eeglab`, the ``pymatreader`` optional dependency
+#     is required. Use the following installation method appropriate for your
+#     environment:
+#     - ``pip install pymatreader```
+#     - ``conda install -c conda-forge pymatreader```
+#     Note that an environment created via the MNE installers includes
+#     ``pymatreader`` by default.
 
 from mne.io import read_raw_eeglab
 

--- a/tutorials/group_level_analysis/plot_group_level_with_individual_clusters.py
+++ b/tutorials/group_level_analysis/plot_group_level_with_individual_clusters.py
@@ -13,8 +13,10 @@ by computing group-level topographies based on individual clusters.
 #     :func:`mne.io.read_raw_eeglab`, the ``pymatreader`` optional dependency
 #     is required. Use the following installation method appropriate for your
 #     environment:
-#     - ``pip install pymatreader```
-#     - ``conda install -c conda-forge pymatreader```
+#
+#     - ``pip install pymatreader``
+#     - ``conda install -c conda-forge pymatreader``
+#
 #     Note that an environment created via the MNE installers includes
 #     ``pymatreader`` by default.
 

--- a/tutorials/group_level_analysis/plot_group_level_with_individual_gfp_peaks.py
+++ b/tutorials/group_level_analysis/plot_group_level_with_individual_gfp_peaks.py
@@ -13,8 +13,10 @@ by computing group level topogrpahies based on individual gfp peaks.
 #     :func:`mne.io.read_raw_eeglab`, the ``pymatreader`` optional dependency
 #     is required. Use the following installation method appropriate for your
 #     environment:
-#     - ``pip install pymatreader```
-#     - ``conda install -c conda-forge pymatreader```
+#
+#     - ``pip install pymatreader``
+#     - ``conda install -c conda-forge pymatreader``
+#
 #     Note that an environment created via the MNE installers includes
 #     ``pymatreader`` by default.
 

--- a/tutorials/group_level_analysis/plot_group_level_with_individual_gfp_peaks.py
+++ b/tutorials/group_level_analysis/plot_group_level_with_individual_gfp_peaks.py
@@ -7,7 +7,16 @@ by computing group level topogrpahies based on individual gfp peaks.
 """
 
 #%%
-# We first start by importing some EEG data.
+# .. note::
+#
+#     The lemon datasets is composed of EEGLAB files. To use the MNE reader
+#     :func:`mne.io.read_raw_eeglab`, the ``pymatreader`` optional dependency
+#     is required. Use the following installation method appropriate for your
+#     environment:
+#     - ``pip install pymatreader```
+#     - ``conda install -c conda-forge pymatreader```
+#     Note that an environment created via the MNE installers includes
+#     ``pymatreader`` by default.
 
 from mne.io import read_raw_eeglab
 

--- a/tutorials/metrics/plot_metrics.py
+++ b/tutorials/metrics/plot_metrics.py
@@ -17,8 +17,10 @@ and the variance expressed by the decomposition.
 #     :func:`mne.io.read_raw_eeglab`, the ``pymatreader`` optional dependency
 #     is required. Use the following installation method appropriate for your
 #     environment:
-#     - ``pip install pymatreader```
-#     - ``conda install -c conda-forge pymatreader```
+#
+#     - ``pip install pymatreader``
+#     - ``conda install -c conda-forge pymatreader``
+#
 #     Note that an environment created via the MNE installers includes
 #     ``pymatreader`` by default.
 

--- a/tutorials/metrics/plot_metrics.py
+++ b/tutorials/metrics/plot_metrics.py
@@ -11,7 +11,16 @@ and the variance expressed by the decomposition.
 """
 
 #%%
-# We first start by importing some EEG data
+# .. note::
+#
+#     The lemon datasets is composed of EEGLAB files. To use the MNE reader
+#     :func:`mne.io.read_raw_eeglab`, the ``pymatreader`` optional dependency
+#     is required. Use the following installation method appropriate for your
+#     environment:
+#     - ``pip install pymatreader```
+#     - ``conda install -c conda-forge pymatreader```
+#     Note that an environment created via the MNE installers includes
+#     ``pymatreader`` by default.
 
 import matplotlib.pyplot as plt
 from mne.io import read_raw_eeglab
@@ -36,7 +45,7 @@ raw.set_eeg_reference("average")
 #
 # We can apply these metrics on clustering solution
 # computed with different values of n_clusters and
-# analyse which give the best clustering solution. 
+# analyse which give the best clustering solution.
 from pycrostates.metrics import (
     silhouette_score,
     calinski_harabasz_score,

--- a/tutorials/preprocessing/plot_extract_gfp_peaks.py
+++ b/tutorials/preprocessing/plot_extract_gfp_peaks.py
@@ -6,7 +6,16 @@ This example demonstrates how to extract global field power (gfp) peaks for an e
 """
 
 #%%
-# We start by loading some example data:
+# .. note::
+#
+#     The lemon datasets is composed of EEGLAB files. To use the MNE reader
+#     :func:`mne.io.read_raw_eeglab`, the ``pymatreader`` optional dependency
+#     is required. Use the following installation method appropriate for your
+#     environment:
+#     - ``pip install pymatreader```
+#     - ``conda install -c conda-forge pymatreader```
+#     Note that an environment created via the MNE installers includes
+#     ``pymatreader`` by default.
 
 import mne
 from mne.io import read_raw_eeglab

--- a/tutorials/preprocessing/plot_extract_gfp_peaks.py
+++ b/tutorials/preprocessing/plot_extract_gfp_peaks.py
@@ -12,8 +12,10 @@ This example demonstrates how to extract global field power (gfp) peaks for an e
 #     :func:`mne.io.read_raw_eeglab`, the ``pymatreader`` optional dependency
 #     is required. Use the following installation method appropriate for your
 #     environment:
-#     - ``pip install pymatreader```
-#     - ``conda install -c conda-forge pymatreader```
+#
+#     - ``pip install pymatreader``
+#     - ``conda install -c conda-forge pymatreader``
+#
 #     Note that an environment created via the MNE installers includes
 #     ``pymatreader`` by default.
 

--- a/tutorials/preprocessing/plot_resampling.py
+++ b/tutorials/preprocessing/plot_resampling.py
@@ -12,8 +12,10 @@ This example demonstrates how to resemple a recording.
 #     :func:`mne.io.read_raw_eeglab`, the ``pymatreader`` optional dependency
 #     is required. Use the following installation method appropriate for your
 #     environment:
-#     - ``pip install pymatreader```
-#     - ``conda install -c conda-forge pymatreader```
+#
+#     - ``pip install pymatreader``
+#     - ``conda install -c conda-forge pymatreader``
+#
 #     Note that an environment created via the MNE installers includes
 #     ``pymatreader`` by default.
 

--- a/tutorials/preprocessing/plot_resampling.py
+++ b/tutorials/preprocessing/plot_resampling.py
@@ -5,6 +5,18 @@ Resampling
 This example demonstrates how to resemple a recording.
 """
 
+#%%
+# .. note::
+#
+#     The lemon datasets is composed of EEGLAB files. To use the MNE reader
+#     :func:`mne.io.read_raw_eeglab`, the ``pymatreader`` optional dependency
+#     is required. Use the following installation method appropriate for your
+#     environment:
+#     - ``pip install pymatreader```
+#     - ``conda install -c conda-forge pymatreader```
+#     Note that an environment created via the MNE installers includes
+#     ``pymatreader`` by default.
+
 import mne
 from mne.io import read_raw_eeglab
 


### PR DESCRIPTION
Addresses #51 with a note in all examples and on the API page of `lemon.data_path()`.