### PR TITLE
Add _check_picks_uniqueness for extract_gfp_peaks

### DIFF
--- a/pycrostates/cluster/_base.py
+++ b/pycrostates/cluster/_base.py
@@ -18,6 +18,7 @@ from ..segmentation import EpochsSegmentation, RawSegmentation
 from ..utils import _corr_vectors
 from ..utils._checks import (
     _check_n_jobs,
+    _check_picks_uniqueness,
     _check_reject_by_annotation,
     _check_tmin_tmax,
     _check_type,
@@ -232,7 +233,7 @@ class _BaseCluster(ABC, ChannelsMixin, ContainsMixin, MontageMixin):
             inst.info, picks, none="all", exclude=[]
         )
         picks = _picks_to_idx(inst.info, picks, none="all", exclude="bads")
-        _BaseCluster._check_picks_uniqueness(inst.info, picks)
+        _check_picks_uniqueness(inst.info, picks)
         ch_not_used = set(picks_bads_inc) - set(picks)
         if len(ch_not_used) != 0:
             if len(ch_not_used) == 1:
@@ -1181,18 +1182,3 @@ class _BaseCluster(ABC, ChannelsMixin, ContainsMixin, MontageMixin):
                 f"Provided: '{n_clusters}'."
             )
         return n_clusters
-
-    @staticmethod
-    def _check_picks_uniqueness(info, picks):
-        info = pick_info(info, picks, copy=True)
-        if len(info.get_channel_types(unique=True)) != 1:
-            ch_types = info.get_channel_types(unique=False)
-            ch_types, counts = np.unique(ch_types, return_counts=True)
-            channels_msg = ", ".join(
-                "%s '%s' channel(s)" % t for t in zip(counts, ch_types)
-            )
-            msg = (
-                "Only one datatype can be selected for fitting, but 'picks' "
-                f"results in {channels_msg}."
-            )
-            raise ValueError(msg)

--- a/pycrostates/cluster/tests/test_base.py
+++ b/pycrostates/cluster/tests/test_base.py
@@ -2,8 +2,6 @@
 
 import numpy as np
 import pytest
-from mne import create_info
-from mne.io.pick import _picks_to_idx
 
 from pycrostates.cluster._base import _BaseCluster
 

--- a/pycrostates/cluster/tests/test_base.py
+++ b/pycrostates/cluster/tests/test_base.py
@@ -71,39 +71,4 @@ def test_reject_short_segments():
     assert [0, 0, 1, 1, 1, 3, 3, 3, 3, 2, 2, 2, 2] == segmentation
 
 
-def test_check_picks_uniqueness():
-    """Test method _check_picks_uniqueness."""
-    # valid
-    info = create_info(5, 1000, "eeg")
-    picks = _picks_to_idx(info, "eeg")
-    _BaseCluster._check_picks_uniqueness(info, picks)
-    picks = _picks_to_idx(info, "all")
-    _BaseCluster._check_picks_uniqueness(info, picks)
-
-    info = create_info(5, 1000, ["eeg", "eeg", "eog", "ecg", "grad"])
-    picks = _picks_to_idx(info, "eeg")
-    _BaseCluster._check_picks_uniqueness(info, picks)
-    picks = _picks_to_idx(info, "eog")
-    _BaseCluster._check_picks_uniqueness(info, picks)
-    picks = _picks_to_idx(info, "ecg")
-    _BaseCluster._check_picks_uniqueness(info, picks)
-    picks = _picks_to_idx(info, "meg")
-    _BaseCluster._check_picks_uniqueness(info, picks)
-    info["bads"] = [info.ch_names[-1]]
-    picks = _picks_to_idx(info, "data")
-    _BaseCluster._check_picks_uniqueness(info, picks)
-
-    # invalid
-    info = create_info(5, 1000, ["eeg", "eeg", "eog", "ecg", "grad"])
-    picks = _picks_to_idx(info, "data")
-    with pytest.raises(ValueError, match="Only one datatype can be selected"):
-        _BaseCluster._check_picks_uniqueness(info, picks)
-    picks = _picks_to_idx(info, "all")
-    with pytest.raises(ValueError, match="Only one datatype can be selected"):
-        _BaseCluster._check_picks_uniqueness(info, picks)
-    picks = _picks_to_idx(info, [1, 2, 3])
-    with pytest.raises(ValueError, match="Only one datatype can be selected"):
-        _BaseCluster._check_picks_uniqueness(info, picks)
-
-
 # TODO: Add tests for _smooth_segmentation and _segment?

--- a/pycrostates/cluster/tests/test_kmeans.py
+++ b/pycrostates/cluster/tests/test_kmeans.py
@@ -893,17 +893,11 @@ def test_picks_fit_predict(caplog):
     )
 
     # test invalid fit
-    with pytest.raises(
-        ValueError, match="Only one datatype can be selected for fitting"
-    ):
+    with pytest.raises(ValueError, match="Only one datatype can be selected"):
         ModK_.fit(raw, picks=None)  # fails -> eeg + grad + mag
-    with pytest.raises(
-        ValueError, match="Only one datatype can be selected for fitting"
-    ):
+    with pytest.raises(ValueError, match="Only one datatype can be selected"):
         ModK_.fit(raw, picks="meg")  # fails -> grad + mag
-    with pytest.raises(
-        ValueError, match="Only one datatype can be selected for fitting"
-    ):
+    with pytest.raises(ValueError, match="Only one datatype can be selected"):
         ModK_.fit(raw, picks="data")  # fails -> eeg + grad + mag
 
     # test valid fit

--- a/pycrostates/preprocessing/extract_gfp_peaks.py
+++ b/pycrostates/preprocessing/extract_gfp_peaks.py
@@ -86,7 +86,9 @@ def extract_gfp_peaks(
 
     # retrieve picks
     picks = _picks_to_idx(inst.info, picks, none="all", exclude="bads")
-    picks_all = _picks_to_idx(inst.info, inst.ch_names, none="all", exclude="bads")
+    picks_all = _picks_to_idx(
+        inst.info, inst.ch_names, none="all", exclude="bads"
+    )
     _check_picks_uniqueness(inst.info, picks)
     # retrieve data array
     kwargs = (
@@ -114,7 +116,7 @@ def extract_gfp_peaks(
             ind_peaks = _extract_gfp_peaks(data[k, :, :], min_peak_distance)
             print(ind_peaks)
             if return_all:
-                peaks.append(data_all[k, :, ind_peaks].T) # TODO: why .T
+                peaks.append(data_all[k, :, ind_peaks].T)  # TODO: why .T
             else:
                 peaks.append(data[k, :, ind_peaks].T)
         peaks = np.hstack(peaks)

--- a/pycrostates/preprocessing/extract_gfp_peaks.py
+++ b/pycrostates/preprocessing/extract_gfp_peaks.py
@@ -51,7 +51,7 @@ def extract_gfp_peaks(
         Note that channels in ``info['bads']`` will be included if their
         names or indices are explicitly provided.
     return_all : bool
-        If True, the returned `~pycrostates.io.ChData` instance will 
+        If True, the returned `~pycrostates.io.ChData` instance will
         include all channels.
         If False (default), the returned `~pycrostates.io.ChData` instance will
         only include channels used for GFP computation (i.e ``picks``).

--- a/pycrostates/preprocessing/extract_gfp_peaks.py
+++ b/pycrostates/preprocessing/extract_gfp_peaks.py
@@ -116,7 +116,7 @@ def extract_gfp_peaks(
             if return_all:
                 del data  # free up memory
                 data = np.squeeze(inst[k].get_data(picks=picks_all, **kwargs))
-            peaks.append(data[:, ind_peaks].T)
+            peaks.append(data[:, ind_peaks])
         peaks = np.hstack(peaks)
 
     n_samples = inst.times.size
@@ -130,7 +130,7 @@ def extract_gfp_peaks(
         peaks.shape[1] / n_samples * 100,
     )
 
-    info = pick_info(inst.info, picks=picks_all if return_all else picks)
+    info = pick_info(inst.info, picks_all if return_all else picks)
     return ChData(peaks, info)
 
 

--- a/pycrostates/preprocessing/extract_gfp_peaks.py
+++ b/pycrostates/preprocessing/extract_gfp_peaks.py
@@ -110,12 +110,12 @@ def extract_gfp_peaks(
     elif isinstance(inst, BaseEpochs):
         peaks = list()  # run epoch per epoch
         for k in range(len(inst)):
-            data = np.squeeze(inst[k].get_data(picks=picks, **kwargs))
+            data = inst[k].get_data(picks=picks, **kwargs)[0, :, :]
             # data is 2D, of shape (n_channels, n_samples)
             ind_peaks = _extract_gfp_peaks(data, min_peak_distance)
             if return_all:
                 del data  # free up memory
-                data = np.squeeze(inst[k].get_data(picks=picks_all, **kwargs))
+                data = inst[k].get_data(picks=picks_all, **kwargs)[0, :, :]
             peaks.append(data[:, ind_peaks])
         peaks = np.hstack(peaks)
 

--- a/pycrostates/preprocessing/extract_gfp_peaks.py
+++ b/pycrostates/preprocessing/extract_gfp_peaks.py
@@ -109,7 +109,7 @@ def extract_gfp_peaks(
         peaks = data[:, ind_peaks]
     elif isinstance(inst, BaseEpochs):
         peaks = list()  # run epoch per epoch
-        for k in range(len(inst)):
+        for k in range(len(inst)):  # pylint: disable=consider-using-enumerate
             data = inst[k].get_data(picks=picks, **kwargs)[0, :, :]
             # data is 2D, of shape (n_channels, n_samples)
             ind_peaks = _extract_gfp_peaks(data, min_peak_distance)

--- a/pycrostates/preprocessing/extract_gfp_peaks.py
+++ b/pycrostates/preprocessing/extract_gfp_peaks.py
@@ -10,6 +10,7 @@ from scipy.signal import find_peaks
 
 from .._typing import CHData, Picks
 from ..utils._checks import (
+    _check_picks_uniqueness,
     _check_reject_by_annotation,
     _check_tmin_tmax,
     _check_type,
@@ -22,7 +23,7 @@ from ..utils._logs import logger, verbose
 @verbose
 def extract_gfp_peaks(
     inst: Union[BaseRaw, BaseEpochs],
-    picks: Picks = None,
+    picks: Picks = "eeg",
     min_peak_distance: int = 2,
     tmin: Optional[float] = None,
     tmax: Optional[float] = None,
@@ -70,7 +71,7 @@ def extract_gfp_peaks(
 
     # retrieve picks
     picks = _picks_to_idx(inst.info, picks, none="all", exclude="bads")
-
+    _check_picks_uniqueness(inst.info, picks)
     # retrieve data array
     kwargs = (
         dict()

--- a/pycrostates/preprocessing/extract_gfp_peaks.py
+++ b/pycrostates/preprocessing/extract_gfp_peaks.py
@@ -51,10 +51,10 @@ def extract_gfp_peaks(
         Note that channels in ``info['bads']`` will be included if their
         names or indices are explicitly provided.
     return_all : bool
-        If True, output ChData instance will include all channels.
-        If False, output ChData instance will only include channels
-        used for GFP computation (i.e picks).
-        Default to False.
+        If True, the returned `~pycrostates.io.ChData` instance will 
+        include all channels.
+        If False (default), the returned `~pycrostates.io.ChData` instance will
+        only include channels used for GFP computation (i.e ``picks``).
     min_peak_distance : int
         Required minimal horizontal distance (``≥ 1`) in samples between
         neighboring peaks. Smaller peaks are removed first until the condition

--- a/pycrostates/preprocessing/extract_gfp_peaks.py
+++ b/pycrostates/preprocessing/extract_gfp_peaks.py
@@ -119,7 +119,7 @@ def extract_gfp_peaks(
             peaks.append(data[:, ind_peaks].T)
         peaks = np.hstack(peaks)
 
-    n_samples = data.shape[-1]
+    n_samples = inst.times.size
     if isinstance(inst, BaseEpochs):
         n_samples *= len(inst)
     logger.info(
@@ -130,10 +130,8 @@ def extract_gfp_peaks(
         peaks.shape[1] / n_samples * 100,
     )
 
-    if return_all:
-        return ChData(peaks, pick_info(inst.info, picks_all))
-    else:
-        return ChData(peaks, pick_info(inst.info, picks))
+    info = pick_info(inst.info, picks=picks_all if return_all else picks)
+    return ChData(peaks, info)
 
 
 def _extract_gfp_peaks(

--- a/pycrostates/preprocessing/extract_gfp_peaks.py
+++ b/pycrostates/preprocessing/extract_gfp_peaks.py
@@ -39,7 +39,15 @@ def extract_gfp_peaks(
     ----------
     inst : Raw | Epochs
         Instance from which to extract :term:`global field power` (GFP) peaks.
-    %(picks_all)s
+    picks : str | list | slice | None
+        Channels to include. Note that all channels selected must have the
+        same type. Slices and lists of integers will be interpreted as
+        channel indices. In lists, channel name strings (e.g.
+        ``['Fp1', 'Fp2']``) will pick the given channels. Can also be the
+        string values “all” to pick all channels, or “data” to pick data
+        channels. ``"eeg"`` (default) will pick all eeg channels.
+        Note that channels in ``info['bads']`` will be included if their
+        names or indices are explicitly provided.
     min_peak_distance : int
         Required minimal horizontal distance (``≥ 1`) in samples between
         neighboring peaks. Smaller peaks are removed first until the condition

--- a/pycrostates/preprocessing/tests/test_extract_gfp_peaks.py
+++ b/pycrostates/preprocessing/tests/test_extract_gfp_peaks.py
@@ -42,7 +42,7 @@ def test_extract_gfp(inst, caplog):
     # with return_all
     ch_data = extract_gfp_peaks(inst, picks=inst.ch_names[0], return_all=True)
     assert isinstance(ch_data, ChData)
-    assert ch_data.info['ch_names'] == inst.ch_names
+    assert ch_data.info["ch_names"] == inst.ch_names
 
     # with tmin/tmax
     tmin = None

--- a/pycrostates/preprocessing/tests/test_extract_gfp_peaks.py
+++ b/pycrostates/preprocessing/tests/test_extract_gfp_peaks.py
@@ -39,6 +39,11 @@ def test_extract_gfp(inst, caplog):
     assert ch_data.info != ch_data2.info
     assert ch_data._data.shape[0] == 1
 
+    # with return_all
+    ch_data = extract_gfp_peaks(inst, picks=inst.ch_names[0], return_all=True)
+    assert isinstance(ch_data, ChData)
+    assert ch_data.info['ch_names'] == inst.ch_names
+
     # with tmin/tmax
     tmin = None
     tmax = 1

--- a/pycrostates/utils/_checks.py
+++ b/pycrostates/utils/_checks.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import numpy as np
 from matplotlib.axes import Axes
+from mne import pick_info
 from mne.utils import check_random_state
 
 
@@ -279,3 +280,18 @@ def _check_tmin_tmax(inst, tmin, tmax):
             f"{inst.times[-1]}s instance."
         )
     return tmin, tmax
+
+
+def _check_picks_uniqueness(info, picks):
+    info = pick_info(info, picks, copy=True)
+    if len(info.get_channel_types(unique=True)) != 1:
+        ch_types = info.get_channel_types(unique=False)
+        ch_types, counts = np.unique(ch_types, return_counts=True)
+        channels_msg = ", ".join(
+            "%s '%s' channel(s)" % t for t in zip(counts, ch_types)
+        )
+        msg = (
+            "Only one datatype can be selected for fitting, but 'picks' "
+            f"results in {channels_msg}."
+        )
+        raise ValueError(msg)

--- a/pycrostates/utils/_checks.py
+++ b/pycrostates/utils/_checks.py
@@ -291,8 +291,7 @@ def _check_picks_uniqueness(info, picks):
         channels_msg = ", ".join(
             "%s '%s' channel(s)" % t for t in zip(counts, ch_types)
         )
-        msg = (
-            "Only one datatype can be selected for fitting, but 'picks' "
+        raise ValueError(
+            "Only one datatype can be selected, but 'picks' "
             f"results in {channels_msg}."
         )
-        raise ValueError(msg)


### PR DESCRIPTION
Check for picks uniqueness in `extract_gfp_peaks`.  It is wrong to compute GFP (np.std) across different channel types.

We can have to approch for the implementation
- compute GFP peaks on picked channels and return all channels (even the not picked ones).
- compute GFP peaks on picked channels and return only picked channels.

I don't see any use case of the first one, but don't have any reason not to do so...

 @mscheltienne any hint ?