### PR TITLE
Add note about find_peaks in the docstring for extract_gfp_peaks and improve glossary x-ref

### DIFF
--- a/docs/source/microstates/glossary.rst
+++ b/docs/source/microstates/glossary.rst
@@ -5,12 +5,17 @@ Glossary
     :sorted:
 
     GFP
-        Global Field Power. For EEG data, it is computed as the standard
-        deviation of the sensors at a given timepoint. Local maxima of the
-        global field power (GFP) are known to represent the portions of EEG
-        data with highest signal-to-noise ratio (:cite:t:`KOENIG20161104`).
+    global field power
+        Global Field Power (GFP) is a measure of the (non-)uniformity of the
+        electromagnetic field at the sensors. It is typically calculated as the
+        standard deviation of the sensor values at each time point. Thus, it is
+        a one-dimensional time series capturing the spatial variability of the
+        signal across sensor locations. Local maxima of the global field power
+        (GFP) are known to represent the portions of EEG data with highest
+        signal-to-noise ratio (:cite:t:`KOENIG20161104`).
 
     GEV
+    global explained variance
         Global explained variance.
         Total explained variance expressed by a given state.
         It is computed as the sum of the explained variance
@@ -35,7 +40,6 @@ Glossary
 
         .. image:: ../../_static/img/inter_cluster_distance_lm.png
             :class: only-light
-
 
     intra-cluster distance
         Distance between two datapoint belonging to the same cluster. Depending

--- a/docs/source/microstates/glossary.rst
+++ b/docs/source/microstates/glossary.rst
@@ -19,8 +19,8 @@ Glossary
         Global explained variance.
         Total explained variance expressed by a given state.
         It is computed as the sum of the explained variance
-        multiplied by the :term:`GFP` of each sample
-        assigned to a given state.
+        multiplied by the :term:`Global Field Power` (:term:`GFP`) of each
+        sample assigned to a given state.
 
     cluster centers
         Arithmetic mean of all the points belonging to the cluster. In the

--- a/pycrostates/preprocessing/extract_gfp_peaks.py
+++ b/pycrostates/preprocessing/extract_gfp_peaks.py
@@ -31,10 +31,10 @@ def extract_gfp_peaks(
     reject_by_annotation: bool = True,
     verbose=None,
 ) -> CHData:
-    """:term:`GFP` peaks extraction.
+    """:term:`Global Field Power` (:term:`GFP`) peaks extraction.
 
-    Extract :term:`global field power` (GFP) peaks from :class:`~mne.Epochs` or
-    :class:`~mne.io.Raw`.
+    Extract :term:`Global Field Power` (:term:`GFP`) peaks from
+    :class:`~mne.Epochs` or :class:`~mne.io.Raw`.
 
     Parameters
     ----------
@@ -68,6 +68,10 @@ def extract_gfp_peaks(
     -------
     ch_data : ChData
         Samples at global field power peaks.
+
+    Notes
+    -----
+    The
     """
     from ..io import ChData
 

--- a/pycrostates/preprocessing/extract_gfp_peaks.py
+++ b/pycrostates/preprocessing/extract_gfp_peaks.py
@@ -71,7 +71,10 @@ def extract_gfp_peaks(
 
     Notes
     -----
-    The
+    The :term:`Global Field Power` (:term:`GFP`) peaks are extracted with
+    :func:`scipy.signal.find_peaks`. Only the ``distance`` argument is
+    filled with the value provided in ``min_peak_distance``. The other
+    arguments are set to their default values.
     """
     from ..io import ChData
 

--- a/tutorials/group_level_analysis/plot_group_level_with_individual_clusters.py
+++ b/tutorials/group_level_analysis/plot_group_level_with_individual_clusters.py
@@ -40,9 +40,9 @@ subject_ids = ["010020", "010021", "010022", "010023", "010024"]
 
 #%%
 # In this example, we start with a subject level analysis by computing
-# individual topographies from :term:`GFP` peaks. Then, the individual
-# topographies are concatenated and used in the group level analysis to fit a
-# second clustering algorithm.
+# individual topographies from :term:`Global Field Power` (:term:`GFP`) peaks.
+# Then, the individual topographies are concatenated and used in the group
+# level analysis to fit a second clustering algorithm.
 
 individual_cluster_centers = list()
 for subject_id in subject_ids:

--- a/tutorials/group_level_analysis/plot_group_level_with_individual_gfp_peaks.py
+++ b/tutorials/group_level_analysis/plot_group_level_with_individual_gfp_peaks.py
@@ -3,7 +3,8 @@ Group level analysis from individual GFP peaks
 ==============================================
 
 In this tutorial, we will learn how to conduct group level analysis
-by computing group level topographies based on individual :term:`GFP` peaks.
+by computing group level topographies based on individual
+:term:`Global Field Power` (:term:`GFP`) peaks.
 """
 
 #%%

--- a/tutorials/metrics/plot_metrics.py
+++ b/tutorials/metrics/plot_metrics.py
@@ -137,7 +137,8 @@ raw.set_eeg_reference("average")
 # For this example, we start by computing each of the score on the clustering
 # results of a :class:`~pycrostates.cluster.ModKMeans` fitted for different
 # ``n_clusters`` ranging from 2 to 8. To speed-up the fitting while preserving
-# most of the information, only the :term:`GFP` peaks are used.
+# most of the information, only the :term:`Global Field Power` (:term:`GFP`)
+# peaks are used.
 
 from pycrostates.metrics import (
     silhouette_score,

--- a/tutorials/preprocessing/plot_extract_gfp_peaks.py
+++ b/tutorials/preprocessing/plot_extract_gfp_peaks.py
@@ -2,8 +2,8 @@
 Global Field Power peaks
 ========================
 
-This example demonstrates how to extract Global Field Power (:term:`GFP`) peaks
-from an EEG recording.
+This example demonstrates how to extract
+:term:`Global Field Power` (:term:`GFP`) peaks from an EEG recording.
 """
 
 #%%
@@ -35,10 +35,10 @@ raw.pick('eeg')
 raw.set_eeg_reference('average')
 
 #%%
-# Global Field Power (:term:`GFP`) is computed as the standard deviation of the
-# sensors at a given timepoint. Local maxima of the Global Field Power
-# (:term:`GFP`) are known to represent the portions of EEG data
-# with highest signal-to-noise ratio\ :footcite:p:`KOENIG20161104`.
+# :term:`Global Field Power` (:term:`GFP`) is computed as the standard
+# deviation of the sensors at a given timepoint. Local maxima of the
+# :term:`Global Field Power` (:term:`GFP`) are known to represent the portions
+# of EEG data with highest signal-to-noise ratio\ :footcite:p:`KOENIG20161104`.
 # We can use the :func:`~pycrostates.preprocessing.extract_gfp_peaks`
 # function to extract samples with the highest Global Field Power.
 # The minimum distance between consecutive peaks can be defined with the


### PR DESCRIPTION
A couple minor improvements to the glossary and to the x-ref, and a note about the parameters used to find the GFP peaks as requested in #64