### PR TITLE
[Paper] Change word to remove the 'replication' mention

### DIFF
--- a/paper/paper.md
+++ b/paper/paper.md
@@ -98,7 +98,7 @@ segmentation features such as smoothing and small segment rejection which are
 especially useful for handling low signal to noise datapoints occurring during
 microstate polarity inversions.
 
-Pycrostates API can replicate most of the analyses proposed in the literature
+Pycrostates API supports most of the analyses proposed in the literature
 [@MICHEL2018577] and in standard but non-python packages such as
 Cartool [@brunet_spatiotemporal_nodate] or MATLAB microstates EEGLab toolboxes.
 Pycrostates is built with a modular and scalable design, following modern


### PR DESCRIPTION
As replication is not the issue, and the point of this sentence was to mention that `pycrostates` can do most the analysis pipeline proposed in the review, I changed the wording. This is I think the only point that was not yet addressed for #65.