### PR TITLE
[DOC] Improve documentation and module docstrings

### DIFF
--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -2,7 +2,6 @@
 
 .. _api_reference:
 
-=============
 API Reference
 =============
 

--- a/docs/source/api/io.rst
+++ b/docs/source/api/io.rst
@@ -1,5 +1,5 @@
-IO
-==
+File I/O
+========
 
 .. currentmodule:: pycrostates.io
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,5 +1,12 @@
 .. include:: ../links.inc
 
+.. raw:: html
+
+    <style type="text/css">h1 {display:none;}</style>
+
+Pycrostates Homepage
+====================
+
 .. image:: ../_static/logos/Pycrostates_logo_white.png
     :class: only-dark
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,8 +1,5 @@
 .. include:: ../links.inc
 
-Pycrostates
-===========
-
 .. image:: ../_static/logos/Pycrostates_logo_white.png
     :class: only-dark
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -32,7 +32,7 @@ Methods
         `MNE standalone installers <mne installers_>`_.
 
         The installers create a conda environment with the entire MNE-ecosystem
-        setup, and more! This installation method is recommanded for beginners.
+        setup, and more! This installation method is recommended for beginners.
 
     .. tab-item:: Pypi
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -3,6 +3,8 @@
 Install
 =======
 
+``pycrostates`` requires Python ``3.7`` or higher.
+
 Dependencies
 ------------
 
@@ -15,13 +17,22 @@ Dependencies
 * ``decorator``
 * ``jinja2``
 
-We require that you use Python ``3.7`` or higher.
-
 ``pycrostates`` works best with the latest stable release of MNE-Python. To
-ensure MNE-Python is up-to-date, see
+ensure MNE-Python is up-to-date, see the
 `MNE installation instructions <mne install_>`_.
 
+Methods
+-------
+
 .. tab-set::
+
+    .. tab-item:: MNE installers
+
+        As of MNE-Python 1.1, ``pycrostates`` is distributed in the
+        `MNE standalone installers <mne installers_>`_.
+
+        The installers create a conda environment with the entire MNE-ecosystem
+        setup, and more! This installation method is recommanded for beginners.
 
     .. tab-item:: Pypi
 
@@ -38,14 +49,6 @@ ensure MNE-Python is up-to-date, see
         .. code-block:: bash
 
             conda install -c conda-forge pycrostates
-
-    .. tab-item:: MNE installers
-
-        As of MNE-Python 1.1, ``pycrostates`` is distributed in the
-        `MNE standalone installers <mne installers_>`_.
-
-        The installers create a conda environment with the entire MNE-ecosystem
-        setup, and more!
 
     .. tab-item:: Snapshot of the current version
 

--- a/pycrostates/cluster/__init__.py
+++ b/pycrostates/cluster/__init__.py
@@ -1,5 +1,18 @@
-"""Module dedicated to clustering algorithms.
-"""
+"""This module contains the clustering algorithms supported by ``pycrostates``.
+Each clustering algorithm is defined as a class with specific initialization
+parameters, a ``fit`` method and a ``predict`` method.
+
+The fitting method ``fit`` requires a dataset as a :class:`~mne.io.Raw`,
+:class:`~mne.Epochs` or :class:`~pycrostates.io.ChData` object. Fitting will
+train the clustering algorithm and determine the microstates maps associated
+with this dataset.
+
+The fitted clustering algorithm can then be used to determine the segmentation
+of the same or of another dataset (recorded using the same system, with the
+same channels) using the ``predict`` method. This method will return either a
+:class:`~pycrostates.segmentation.RawSegmentation` or a
+:class:`~pycrostates.segmentation.EpochsSegmentation` depending on the dataset
+to segment."""
 
 from .kmeans import ModKMeans  # noqa: F401
 

--- a/pycrostates/datasets/__init__.py
+++ b/pycrostates/datasets/__init__.py
@@ -1,4 +1,9 @@
-"""Module dedicated to example datasets."""
+"""This module contains functions to fetch remote datasets. All the dataset
+fetchers are available in :mod:`pycrostates.datasets`. To download any of the
+datasets, use the ``data_path`` function associated to this dataset.
+
+All fetchers will check the default download location first to see if the
+dataset is already on your computer, and only download it if necessary."""
 
 from . import lemon
 

--- a/pycrostates/io/__init__.py
+++ b/pycrostates/io/__init__.py
@@ -1,4 +1,4 @@
-"""IO module for reading and writing data."""
+"""File I/O module for reading and writing data."""
 
 from .ch_data import ChData
 from .meas_info import ChInfo

--- a/pycrostates/metrics/__init__.py
+++ b/pycrostates/metrics/__init__.py
@@ -1,4 +1,6 @@
-"""Metric module for evaluating clusters."""
+"""This module contains function to evaluate fitted clusters. All metrics will
+require a fitted cluster as input. See :mod:`pycrostates.cluster` for available
+clustering algorithms."""
 
 from .calinski_harabasz import calinski_harabasz_score
 from .davies_bouldin import davies_bouldin_score

--- a/pycrostates/preprocessing/__init__.py
+++ b/pycrostates/preprocessing/__init__.py
@@ -1,4 +1,7 @@
-"""Preprocessing module for preprocessing data."""
+"""This module contains functions to preprocess data for microstates analysis.
+General preprocessing, such as filtering, interpolation, ICA, ... should be
+applied prior to those functions using the MNE :mod:`~mne.preprocessing`
+module."""
 
 from .extract_gfp_peaks import extract_gfp_peaks
 from .resample import resample

--- a/pycrostates/viz/__init__.py
+++ b/pycrostates/viz/__init__.py
@@ -1,4 +1,5 @@
-"""Viz module for Visualization routines."""
+"""Visualization routines that can be called directly or from methods of the
+main ``pycrostates`` classes."""
 
 from .cluster_centers import plot_cluster_centers
 from .segmentation import plot_epoch_segmentation, plot_raw_segmentation


### PR DESCRIPTION
3 changes:
- I removed the duplicate title on the `index` page
- I re-ordered a bit the installation page, mentioning first the version of Python required and then the dependencies
- I improved a bit the docstrings of the different modules which appear on the API Reference page

For this last point, the idea was to detail a bit the general structure of the module, e.g. when all functions/classes within this module adhere to a similar design.