### PR TITLE
[DOC] Add BibClean to format references.bib

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -45,3 +45,5 @@ jobs:
           skip: ./.git,./build,./.github,*.bib
       - name: Run pydocstyle
         run: pydocstyle .
+      - name: Run bibclean
+        run: bibclean-check docs/references.bib

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1,122 +1,105 @@
-% Encoding: UTF-8
-%
-% If available, include a DOI (preferred) *or* a URL for a given reference, but
-# not both, as the DOI turns into a link which is redundant with the URL.
-
-% MNE-C
-@article{GramfortEtAl2014,
-  title = {{{MNE}} Software for Processing {{MEG}} and {{EEG}} Data},
-  author = {Gramfort, Alexandre and Luessi, Martin and Larson, Eric and Engemann, Denis A. and Strohmeier, Daniel and Brodbeck, Christian and Parkkonen, Lauri and H{\"a}m{\"a}l{\"a}inen, Matti S.},
-  year = {2014},
-  volume = {86},
-  pages = {446--460},
-  doi = {10.1016/j.neuroimage.2013.10.027},
-  journal = {NeuroImage},
-}
-% MNE-Python
-@article{GramfortEtAl2013a,
-  title = {{{MEG}} and {{EEG}} Data Analysis with {{MNE}}-{{Python}}},
-  author = {Gramfort, Alexandre and Luessi, Martin and Larson, Eric and Engemann, Denis A. and Strohmeier, Daniel and Brodbeck, Christian and Goj, Roman and Jas, Mainak and Brooks, Teon and Parkkonen, Lauri and H{\"a}m{\"a}l{\"a}inen, Matti S.},
-  year = {2013},
-  volume = {7},
-  pages = {1--13},
-  doi = {10.3389/fnins.2013.00267},
-  journal = {Frontiers in Neuroscience},
-  number = {267}
-}
-
-% Michel 2018 - microstates review
-@article{MICHEL2018577,
-  title = {EEG microstates as a tool for studying the temporal dynamics of whole-brain neuronal networks: A review},
-  journal = {NeuroImage},
-  volume = {180},
-  pages = {577-593},
-  year = {2018},
-  note = {Brain Connectivity Dynamics},
-  issn = {1053-8119},
-  doi = {10.1016/j.neuroimage.2017.11.062},
-  author = {Christoph M. Michel and Thomas Koenig},
-  keywords = {EEG microstates, Resting state networks, Consciousness, Psychiatric disease, State-dependent information processing, Metastability},
-}
-% Modified K-Means
-@article{Marqui1995,
-  author={Pascual-Marqui, R.D. and Michel, C.M. and Lehmann, D.},
-  journal={IEEE Transactions on Biomedical Engineering},
-  title={Segmentation of brain electrical activity into microstates: model estimation and validation},
-  year={1995},
-  volume={42},
-  number={7},
-  pages={658-665},
-  doi={10.1109/10.391164}
-}
-
-% Lemon datasets
 @article{babayan_mind-brain-body_2019,
-  title = {A mind-brain-body dataset of {MRI}, {EEG}, cognition, emotion, and peripheral physiology in young and old adults},
-  volume = {6},
-  issn = {2052-4463},
-  doi = {10.1038/sdata.2018.308},
-  number = {1},
-  journal = {Scientific Data},
-  author = {Babayan, Anahit and Erbey, Miray and Kumral, Deniz},
-  year = {2019},
-  pages = {180308},
+ author = {Babayan, Anahit and Erbey, Miray and Kumral, Deniz},
+ doi = {10.1038/sdata.2018.308},
+ journal = {Scientific Data},
+ number = {1},
+ pages = {180308},
+ title = {A mind-brain-body dataset of {MRI}, {EEG}, cognition, emotion, and peripheral physiology in young and old adults},
+ volume = {6},
+ year = {2019}
 }
 
-# Global Field Power
-@article{KOENIG20161104,
-  title = {Inappropriate assumptions about EEG state changes and their impact on the quantification of EEG state dynamics},
-  journal = {NeuroImage},
-  volume = {125},
-  pages = {1104-1106},
-  year = {2016},
-  issn = {1053-8119},
-  doi = {10.1016/j.neuroimage.2015.06.035},
-  author = {Thomas Koenig and Daniel Brandeis},
-  keywords = {Microstates, Global field power, Topographic change}
-}
-
-% Metrics
-@article{Silhouettes,
-  title = {Silhouettes: A graphical aid to the interpretation and validation of cluster analysis},
-  journal = {Journal of Computational and Applied Mathematics},
-  volume = {20},
-  pages = {53-65},
-  year = {1987},
-  issn = {0377-0427},
-  doi = {10.1016/0377-0427(87)90125-7},
-  author = {Peter J. Rousseeuw},
-  keywords = {Graphical display, cluster analysis, clustering validity, classification},
-}
 @article{Calinski-Harabasz,
-  author = {T. Caliński and J. Harabasz},
-  title = {A dendrite method for cluster analysis},
-  journal = {Communications in Statistics},
-  volume = {3},
-  number = {1},
-  pages = {1-27},
-  year  = {1974},
-  publisher = {Taylor & Francis},
-  doi = {10.1080/03610927408827101},
+ author = {T. Caliński and J. Harabasz},
+ doi = {10.1080/03610927408827101},
+ journal = {Communications in Statistics},
+ number = {1},
+ pages = {1-27},
+ title = {A dendrite method for cluster analysis},
+ volume = {3},
+ year = {1974}
 }
-@article{Dunn,
-  author = {J. C. Dunn†},
-  title = {Well-Separated Clusters and Optimal Fuzzy Partitions},
-  journal = {Journal of Cybernetics},
-  volume = {4},
-  number = {1},
-  pages = {95-104},
-  year  = {1974},
-  publisher = {Taylor & Francis},
-  doi = {10.1080/01969727408546059},
-}
+
 @article{Davies-Bouldin,
-  author={Davies, David L. and Bouldin, Donald W.},
-  journal={IEEE Transactions on Pattern Analysis and Machine Intelligence},
-  title={A Cluster Separation Measure},
-  year={1979},
-  volume={PAMI-1},
-  number={2},
-  pages={224-227},
-  doi={10.1109/TPAMI.1979.4766909}
+ author = {Davies, David L. and Bouldin, Donald W.},
+ doi = {10.1109/TPAMI.1979.4766909},
+ journal = {IEEE Transactions on Pattern Analysis and Machine Intelligence},
+ number = {2},
+ pages = {224-227},
+ title = {A Cluster Separation Measure},
+ volume = {PAMI-1},
+ year = {1979}
+}
+
+@article{Dunn,
+ author = {J. C. Dunn†},
+ doi = {10.1080/01969727408546059},
+ journal = {Journal of Cybernetics},
+ number = {1},
+ pages = {95-104},
+ title = {Well-Separated Clusters and Optimal Fuzzy Partitions},
+ volume = {4},
+ year = {1974}
+}
+
+@article{GramfortEtAl2013a,
+ author = {Gramfort, Alexandre and Luessi, Martin and Larson, Eric and Engemann, Denis A. and Strohmeier, Daniel and Brodbeck, Christian and Goj, Roman and Jas, Mainak and Brooks, Teon and Parkkonen, Lauri and H{\"a}m{\"a}l{\"a}inen, Matti S.},
+ doi = {10.3389/fnins.2013.00267},
+ journal = {Frontiers in Neuroscience},
+ number = {267},
+ pages = {1--13},
+ title = {{{MEG}} and {{EEG}} Data Analysis with {{MNE}}-{{Python}}},
+ volume = {7},
+ year = {2013}
+}
+
+@article{GramfortEtAl2014,
+ author = {Gramfort, Alexandre and Luessi, Martin and Larson, Eric and Engemann, Denis A. and Strohmeier, Daniel and Brodbeck, Christian and Parkkonen, Lauri and H{\"a}m{\"a}l{\"a}inen, Matti S.},
+ doi = {10.1016/j.neuroimage.2013.10.027},
+ journal = {NeuroImage},
+ pages = {446--460},
+ title = {{{MNE}} Software for Processing {{MEG}} and {{EEG}} Data},
+ volume = {86},
+ year = {2014}
+}
+
+@article{KOENIG20161104,
+ author = {Thomas Koenig and Daniel Brandeis},
+ doi = {10.1016/j.neuroimage.2015.06.035},
+ journal = {NeuroImage},
+ pages = {1104-1106},
+ title = {Inappropriate assumptions about EEG state changes and their impact on the quantification of EEG state dynamics},
+ volume = {125},
+ year = {2016}
+}
+
+@article{Marqui1995,
+ author = {Pascual-Marqui, R.D. and Michel, C.M. and Lehmann, D.},
+ doi = {10.1109/10.391164},
+ journal = {IEEE Transactions on Biomedical Engineering},
+ number = {7},
+ pages = {658-665},
+ title = {Segmentation of brain electrical activity into microstates: model estimation and validation},
+ volume = {42},
+ year = {1995}
+}
+
+@article{MICHEL2018577,
+ author = {Christoph M. Michel and Thomas Koenig},
+ doi = {10.1016/j.neuroimage.2017.11.062},
+ journal = {NeuroImage},
+ pages = {577-593},
+ title = {EEG microstates as a tool for studying the temporal dynamics of whole-brain neuronal networks: A review},
+ volume = {180},
+ year = {2018}
+}
+
+@article{Silhouettes,
+ author = {Peter J. Rousseeuw},
+ doi = {10.1016/0377-0427(87)90125-7},
+ journal = {Journal of Computational and Applied Mathematics},
+ pages = {53-65},
+ title = {Silhouettes: A graphical aid to the interpretation and validation of cluster analysis},
+ volume = {20},
+ year = {1987}
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ docs = [
     'sphinx-issues',
 ]
 style = [
+    'bibclean',
     'black',
     'codespell',
     'isort',
@@ -128,7 +129,7 @@ extend_skip_glob = [
     'setup.py',
     'docs/*',
     'tutorials/*',
-    'pycrostates/html_templates/repr/*'
+    'pycrostates/html_templates/repr/*',
 ]
 
 [tool.pydocstyle]


### PR DESCRIPTION
I made this static checker/auto-formatter to clean-up the BibTex files provided to `sphinxcontrib-bibtex`, works nicely ;)
https://mscheltienne.github.io/bibclean/dev/index.html

The run in the CI workflow is similar to `pydocstyle`, it exits with code `0` if the file is valid, `1` if it's invalid and `2` if the config is invalid.