### PR TITLE
[MNT] Run build and tests workflows on latest Python 3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: [3.8, 3.9, "3.10", "3.11"]
     name: ${{ matrix.os }} - ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}-latest
     defaults:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,6 +60,11 @@ stages:
           PYTHON_VERSION: '3.10'
           MNE_DEV: false
           CACHE_MNE_PATH: $(CACHE_PATH_MNE_LINUX)
+        linux 3.11:
+          VM_IMAGE: 'ubuntu-latest'
+          PYTHON_VERSION: '3.11'
+          MNE_DEV: false
+          CACHE_MNE_PATH: $(CACHE_PATH_MNE_LINUX)
         linux 3.10 MNE-dev:
           VM_IMAGE: 'ubuntu-latest'
           PYTHON_VERSION: '3.10'
@@ -80,6 +85,11 @@ stages:
           PYTHON_VERSION: '3.10'
           MNE_DEV: false
           CACHE_MNE_PATH: $(CACHE_PATH_MNE_MACOS)
+        macOS 3.11:
+          VM_IMAGE: 'macOS-latest'
+          PYTHON_VERSION: '3.11'
+          MNE_DEV: false
+          CACHE_MNE_PATH: $(CACHE_PATH_MNE_MACOS)
         windows 3.8:
           VM_IMAGE: 'windows-latest'
           PYTHON_VERSION: '3.8'
@@ -93,6 +103,11 @@ stages:
         windows 3.10:
           VM_IMAGE: 'windows-latest'
           PYTHON_VERSION: '3.10'
+          MNE_DEV: false
+          CACHE_MNE_PATH: $(CACHE_PATH_MNE_WINDOWS)
+        windows 3.11:
+          VM_IMAGE: 'windows-latest'
+          PYTHON_VERSION: '3.11'
           MNE_DEV: false
           CACHE_MNE_PATH: $(CACHE_PATH_MNE_WINDOWS)
     pool:

--- a/pycrostates/segmentation/tests/test_segmentation.py
+++ b/pycrostates/segmentation/tests/test_segmentation.py
@@ -94,19 +94,19 @@ def test_properties(ModK, inst, caplog):
 
     # test that properties can not be set
     segmentation = ModK.predict(inst)
-    with pytest.raises(AttributeError, match="can't set attribute"):
+    with pytest.raises(AttributeError):
         segmentation.predict_parameters = dict()
-    with pytest.raises(AttributeError, match="can't set attribute"):
+    with pytest.raises(AttributeError):
         segmentation.labels = np.zeros((raw.times.size,))
-    with pytest.raises(AttributeError, match="can't set attribute"):
+    with pytest.raises(AttributeError):
         segmentation.cluster_names = ["1", "0", "2", "3"]
-    with pytest.raises(AttributeError, match="can't set attribute"):
+    with pytest.raises(AttributeError):
         segmentation.cluster_centers_ = np.zeros(
             (4, len(inst.ch_names) - len(inst.info["bads"]))
         )
 
     # test raw/epochs specific
-    with pytest.raises(AttributeError, match="can't set attribute"):
+    with pytest.raises(AttributeError):
         if isinstance(inst, BaseRaw):
             segmentation.raw = raw
         if isinstance(inst, BaseEpochs):


### PR DESCRIPTION
Closes #99

Let's see if it's green. I think the parts of MNE we use are already compatible, but probably not MNE-full because of all the viz dependencies.