### PR TITLE
[MNT] Unpin matplotlib

### DIFF
--- a/pycrostates/cluster/aahc.py
+++ b/pycrostates/cluster/aahc.py
@@ -236,7 +236,6 @@ class AAHCluster(_BaseCluster):
 
         n_steps = n_frame - n_clusters
         while cluster.shape[1] > n_clusters:
-
             step = n_frame - cluster.shape[1]
 
             to_remove = np.argmin(GEV)
@@ -260,7 +259,6 @@ class AAHCluster(_BaseCluster):
             for c in cluster_to_update:
                 members = assignment == c
                 if ignore_polarity:
-
                     old_weight = len(new_assignment == c) / members.sum()
 
                     sgn = np.sign(old_cluster @ cluster[:, c])

--- a/pycrostates/viz/segmentation.py
+++ b/pycrostates/viz/segmentation.py
@@ -8,6 +8,7 @@ from matplotlib import pyplot as plt
 from matplotlib.axes import Axes
 from mne import BaseEpochs
 from mne.io import BaseRaw
+from mne.utils import check_version
 from numpy.typing import NDArray
 
 from ..utils._checks import _check_type
@@ -255,11 +256,21 @@ def _plot_segmentation(
     state_labels = [-1] + list(range(n_clusters))
     cluster_names = ["unlabeled"] + cluster_names
     n_colors = n_clusters + 1
-    if cmap is None:
-        cmap = colormaps["viridis"]
-    elif isinstance(cmap, str):
-        cmap = colormaps[cmap]  # the cmap name is checked by matplotlib
-    cmap = cmap.resampled(n_colors)
+    if check_version("matplotlib", "3.6"):
+        if cmap is None:
+            cmap = colormaps["viridis"]
+        elif isinstance(cmap, str):
+            cmap = colormaps[cmap]  # the cmap name is checked by matplotlib
+        cmap = cmap.resampled(n_colors)
+    else:
+        if isinstance(cmap, (str, type(None))):
+            cmap = plt.cm.get_cmap(cmap, n_colors)
+        else:
+            raise RuntimeError(
+                "User-defined colormaps are supported as of matplotlib 3.6 "
+                "and above. Please update matplotlib or provide a colormap "
+                "name as a string."
+            )
 
     # plot
     axes.plot(times, gfp, **kwargs)

--- a/pycrostates/viz/segmentation.py
+++ b/pycrostates/viz/segmentation.py
@@ -298,7 +298,7 @@ def _compatibility_cmap(
     cmap: Optional[Union[str, colors.Colormap]],
     n_colors: int,
 ):
-    """Converts the 'cmap' argument to a colormap
+    """Convert the 'cmap' argument to a colormap.
 
     Matplotlib 3.6 introduced a deprecation of plt.cm.get_cmap().
     When support for the 3.6 version is dropped, this checker can be removed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,13 +29,14 @@ classifiers = [
     'Operating System :: Unix',
     'Operating System :: MacOS',
     'Programming Language :: Python :: 3 :: Only',
-    'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
     'Natural Language :: English',
     'License :: OSI Approved :: BSD License',
     'Intended Audience :: Science/Research',
+    'Intended Audience :: Developers',
     'Topic :: Scientific/Engineering',
 ]
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     'scipy',
     'mne>=1.0.0',
     'joblib',
-    'matplotlib>=3.6.0',
+    'matplotlib',
     'scikit-learn',
     'pooch',
     'decorator',


### PR DESCRIPTION
Following #77, I've pin the version of matplotlib. 
It's not the best idea as the pin is very strict with only the latest version. It may results in conflicts with environments with many packages.

Usually, we should aim to support 4/5 minor version of our dependencies. In this PR, I reverted some of the changes from #77 to make sure older versions of matplotlib would still work.