### PR TITLE
BUGFIX and performance improvement in AAHC clustering

### DIFF
--- a/pycrostates/cluster/aahc.py
+++ b/pycrostates/cluster/aahc.py
@@ -1,6 +1,5 @@
 """Atomize and Agglomerate Hierarchical Clustering (AAHC)."""
 
-from functools import wraps as func_wraps
 from pathlib import Path
 from typing import Any, Optional, Tuple, Union
 
@@ -15,23 +14,6 @@ from ..utils._checks import _check_type
 from ..utils._docs import copy_doc, fill_doc
 from ..utils._logs import logger
 from ._base import _BaseCluster
-
-# if we have numba, use its jit interface
-try:
-    from numba import njit
-except ImportError:
-
-    def njit(cache=False):  # pylint: disable=unused-argument
-        """Define dummy decorator for numba."""
-
-        def decorator(func):
-            @func_wraps(func)
-            def wrapper(*args, **kwargs):
-                return func(*args, **kwargs)
-
-            return wrapper
-
-        return decorator
 
 
 @fill_doc
@@ -237,14 +219,10 @@ class AAHCluster(_BaseCluster):
 
         assignment = np.arange(n_frame)
 
-        n_steps = n_frame - n_clusters
         while cluster.shape[1] > n_clusters:
-            step = n_frame - cluster.shape[1]
 
             to_remove = np.argmin(GEV)
             orphans = assignment == to_remove
-
-            old_cluster = cluster[:, to_remove].copy()
 
             cluster = np.delete(cluster, to_remove, axis=1)
             GEV = np.delete(GEV, to_remove, axis=0)
@@ -262,44 +240,8 @@ class AAHCluster(_BaseCluster):
             for c in cluster_to_update:
                 members = assignment == c
                 if ignore_polarity:
-                    old_weight = len(new_assignment == c) / members.sum()
-
-                    sgn = np.sign(old_cluster @ cluster[:, c])
-
-                    first_pc_init = (
-                        old_weight * sgn * old_cluster
-                        + (1.0 - old_weight) * cluster[:, c]
-                    )
-
-                    (
-                        first_pc,
-                        _,
-                        converged,
-                    ) = AAHCluster._first_principal_component(
-                        data[:, members], first_pc_init, max_iter=n_chan
-                    )
-                    if converged:
-                        logger.debug(
-                            "AAHC %d/%d: " "power iterations converged.",
-                            step,
-                            n_steps,
-                        )
-                    else:
-                        logger.debug(
-                            "AAHC %d/%d "
-                            "power iteration did not converge. "
-                            "Computing fallback solution.",
-                            step,
-                            n_steps,
-                        )
-                        # fall back to covariance estimation
-                        # and eigenvalue computation
-                        data_cov = data[:, members] @ data[:, members].T
-                        _, evecs = np.linalg.eigh(data_cov)
-                        # eigenvector at largest eigenvalue
-                        first_pc = evecs[:, -1]
-
-                    cluster[:, c] = first_pc
+                    evecs, _, _ = np.linalg.svd(data[:, members], full_matrices=False)
+                    cluster[:, c] = evecs[:,0]
                 else:
                     cluster[:, c] = np.mean(data[:, members], axis=1)
                     cluster[:, c] /= np.linalg.norm(
@@ -312,58 +254,6 @@ class AAHCluster(_BaseCluster):
         return cluster.T, assignment
 
     # pylint: enable=too-many-locals
-
-    @staticmethod
-    @njit(cache=True)
-    def _first_principal_component(
-        X: NDArray[float],
-        v0: NDArray[float],
-        tol: float = 1e-6,
-        max_iter: int = 100,
-    ) -> Tuple[NDArray[float], float, bool]:
-        """Compute first principal component.
-
-        Parameters
-        ----------
-        X : numpy.ndarray
-            Input data matrix with dimensions (channels x observations)
-        v0 : numpy.ndarray
-            Initial estimate of the principal vector with dimensions
-            (channels,).
-        tol : float (1e-6 by default)
-            Tolerance for convergence.
-        max_iter : int (100 by default)
-            Maximum number of iterations to estimate the first principal
-            component.
-
-        Returns
-        -------
-        v : numpy.ndarray
-            Estimated principal component vector.
-        eig : float
-            Eigenvalue of the covariance matrix of X (channels x channels)
-        converged : bool
-            False, if `max_iter` were reached.
-
-        See :footcite:t:`Roweis1997` for additional information.
-        """
-        v = v0.flatten()
-        assert v.shape[0] == X.shape[0]
-        v /= np.linalg.norm(v)
-
-        converged = False
-        for _ in range(max_iter):
-            s = np.sum((np.expand_dims(v, 0) @ X) * X, axis=1)
-
-            eig = s.dot(v)
-            s_norm = np.linalg.norm(s)
-
-            if np.linalg.norm(eig * v - s) / s_norm < tol:
-                converged = True
-                break
-            v = s / s_norm
-        return v, eig, converged
-
     # --------------------------------------------------------------------
 
     @property

--- a/pycrostates/cluster/aahc.py
+++ b/pycrostates/cluster/aahc.py
@@ -232,6 +232,9 @@ class AAHCluster(_BaseCluster):
 
         GEV = np.sum(data * cluster, axis=0)
 
+        if ignore_polarity:
+            GEV = np.abs(GEV)
+
         assignment = np.arange(n_frame)
 
         n_steps = n_frame - n_clusters
@@ -302,7 +305,7 @@ class AAHCluster(_BaseCluster):
                     cluster[:, c] /= np.linalg.norm(
                         cluster[:, c], axis=0, keepdims=True
                     )
-                new_fit = cluster[:, slice(c, c + 1)] * data[:, members]
+                new_fit = cluster[:, slice(c, c + 1)].T @ data[:, members]
                 if ignore_polarity:
                     new_fit = np.abs(new_fit)
                 GEV[c] = np.sum(new_fit)

--- a/pycrostates/cluster/aahc.py
+++ b/pycrostates/cluster/aahc.py
@@ -240,8 +240,10 @@ class AAHCluster(_BaseCluster):
             for c in cluster_to_update:
                 members = assignment == c
                 if ignore_polarity:
-                    evecs, _, _ = np.linalg.svd(data[:, members], full_matrices=False)
-                    cluster[:, c] = evecs[:,0]
+                    evecs, _, _ = np.linalg.svd(
+                        data[:, members], full_matrices=False
+                    )
+                    cluster[:, c] = evecs[:, 0]
                 else:
                     cluster[:, c] = np.mean(data[:, members], axis=1)
                     cluster[:, c] /= np.linalg.norm(

--- a/pycrostates/cluster/aahc.py
+++ b/pycrostates/cluster/aahc.py
@@ -220,7 +220,6 @@ class AAHCluster(_BaseCluster):
         assignment = np.arange(n_frame)
 
         while cluster.shape[1] > n_clusters:
-
             to_remove = np.argmin(GEV)
             orphans = assignment == to_remove
 


### PR DESCRIPTION
This PR implements the following:

1. I identified and fixed a bug in the AAHC implementation in aahc.py L305 [1]. In case ignore_polarity=True, the in-product between the cluster and its members was not computed correctly. (element-wise absolute value vs. absolute value of the in-product).
2. I replaced the custom implementation of the power iteration algorithm to estimate the first principal component (if ignore_polarity=True). The new implementation uses scipy's SVD. Advantages: (i) for typical problem settings (dozens of channels) the new method is faster (ii) there are no additional dependencies and less code to maintain.


[1] https://github.com/vferat/pycrostates/blob/main/pycrostates/cluster/aahc.py#L305