### PR TITLE
Fix MNE-main and doc-build CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -125,7 +125,7 @@ stages:
       displayName: 'Install dependencies and MNE (stable)'
     - script: |
         python -m pip uninstall -y mne
-        python -m pip install --progress-bar off --no-deps https://github.com/mne-tools/mne-python/archive/main.zip
+        python -m pip install --progress-bar off --no-deps git+https://github.com/mne-tools/mne-python
       condition: eq(variables.MNE_DEV, 'true')
       displayName: 'Install MNE (main)'
     - script: mne sys_info -pd

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -77,13 +77,6 @@ default_role = "py:obj"
 
 # -- options for HTML output -------------------------------------------------
 html_theme = "pydata_sphinx_theme"
-
-# Add any paths that contain custom static files (such as style sheets) here,
-# relative to this directory. They are copied after the builtin static files,
-# so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = [str(Path(__file__).parent.parent / "_static")]
-html_css_files = ["style.css"]
-
 html_theme_options = {
     "logo": {
         "image_light": "logos/Pycrostates_logo_black.png",
@@ -106,6 +99,11 @@ html_theme_options = {
     ],
 }
 
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = [str(Path(__file__).parent.parent / "_static")]
+html_css_files = ["style.css"]
 # If true, links to the reST sources are added to the pages.
 html_show_sourcelink = False
 html_copy_source = False

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -77,6 +77,13 @@ default_role = "py:obj"
 
 # -- options for HTML output -------------------------------------------------
 html_theme = "pydata_sphinx_theme"
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = [str(Path(__file__).parent.parent / "_static")]
+html_css_files = ["style.css"]
+
 html_theme_options = {
     "logo": {
         "image_light": "logos/Pycrostates_logo_black.png",
@@ -99,11 +106,6 @@ html_theme_options = {
     ],
 }
 
-# Add any paths that contain custom static files (such as style sheets) here,
-# relative to this directory. They are copied after the builtin static files,
-# so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = [str(Path(__file__).parent.parent / "_static")]
-html_css_files = ["style.css"]
 # If true, links to the reST sources are added to the pages.
 html_show_sourcelink = False
 html_copy_source = False

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -79,8 +79,8 @@ default_role = "py:obj"
 html_theme = "pydata_sphinx_theme"
 html_theme_options = {
     "logo": {
-        "image_light": "logos/Pycrostates_logo_black.png",
-        "image_dark": "logos/Pycrostates_logo_white.png",
+        "image_light": "../_static/logos/Pycrostates_logo_black.png",
+        "image_dark": "../_static/logos/Pycrostates_logo_white.png",
     },
     "icon_links": [
         {


### PR DESCRIPTION
MNE moved to `setuptools_scm` to manage versions in https://github.com/mne-tools/mne-python/pull/11517 and that broke our azure pipeline. Cloning the repository with `git+` should hopefully fix this.

Also fixes the documentation build which can not find the logos anymore.