### PR TITLE
Improve logger and fill_doc, copy_doc and verbose decorator

### DIFF
--- a/pycrostates/_version.py
+++ b/pycrostates/_version.py
@@ -1,8 +1,5 @@
 """Version number."""
 
-try:
-    from importlib.metadata import version
-except ImportError:
-    from importlib_metadata import version  # for python 3.7
+from importlib.metadata import version
 
 __version__ = version(__package__)

--- a/pycrostates/cluster/_base.py
+++ b/pycrostates/cluster/_base.py
@@ -558,6 +558,7 @@ class _BaseCluster(ABC, ChannelsMixin, ContainsMixin, MontageMixin):
         self._check_fit()
         _check_type(fname, ("path-like",), "fname")
 
+    @fill_doc
     @verbose
     def predict(
         self,

--- a/pycrostates/cluster/_base.py
+++ b/pycrostates/cluster/_base.py
@@ -24,8 +24,7 @@ from ..utils._checks import (
     _check_value,
 )
 from ..utils._docs import fill_doc
-from ..utils._logs import _set_verbose, logger
-from ..utils._logs import verbose as verbose_decorator
+from ..utils._logs import logger, verbose
 from ..utils.mixin import ChannelsMixin, ContainsMixin, MontageMixin
 from ..viz import plot_cluster_centers
 
@@ -185,6 +184,7 @@ class _BaseCluster(ABC, ChannelsMixin, ContainsMixin, MontageMixin):
 
     @abstractmethod
     @fill_doc
+    @verbose
     def fit(
         self,
         inst: Union[BaseRaw, BaseEpochs, CHData],
@@ -217,8 +217,6 @@ class _BaseCluster(ABC, ChannelsMixin, ContainsMixin, MontageMixin):
         %(verbose)s
         """
         from ..io import ChData, ChInfo
-
-        _set_verbose(verbose)
 
         self._check_unfitted()
         _check_type(inst, (BaseRaw, BaseEpochs, ChData), item_name="inst")
@@ -560,7 +558,7 @@ class _BaseCluster(ABC, ChannelsMixin, ContainsMixin, MontageMixin):
         self._check_fit()
         _check_type(fname, ("path-like",), "fname")
 
-    @verbose_decorator
+    @verbose
     def predict(
         self,
         inst: Union[BaseRaw, BaseEpochs],

--- a/pycrostates/utils/_checks.py
+++ b/pycrostates/utils/_checks.py
@@ -302,7 +302,7 @@ def _check_picks_uniqueness(info, picks):
 
 
 @fill_doc
-def check_verbose(verbose: Any) -> int:
+def _check_verbose(verbose: Any) -> int:
     """Check that the value of verbose is valid.
 
     Parameters

--- a/pycrostates/utils/_checks.py
+++ b/pycrostates/utils/_checks.py
@@ -1,15 +1,19 @@
 """Utility functions for checking types and values. Inspired from MNE."""
 
+import logging
 import multiprocessing as mp
 import operator
 import os
 from itertools import product
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 from matplotlib.axes import Axes
 from mne import pick_info
 from mne.utils import check_random_state
+
+from ._docs import fill_doc
 
 
 def _ensure_int(item, item_name=None):
@@ -295,3 +299,48 @@ def _check_picks_uniqueness(info, picks):
             "Only one datatype can be selected, but 'picks' "
             f"results in {channels_msg}."
         )
+
+
+@fill_doc
+def check_verbose(verbose: Any) -> int:
+    """Check that the value of verbose is valid.
+
+    Parameters
+    ----------
+    %(verbose)s
+
+    Returns
+    -------
+    verbose : int
+        The verbosity level as an integer.
+    """
+    logging_types = dict(
+        DEBUG=logging.DEBUG,
+        INFO=logging.INFO,
+        WARNING=logging.WARNING,
+        ERROR=logging.ERROR,
+        CRITICAL=logging.CRITICAL,
+    )
+
+    _check_type(verbose, (bool, str, "int", None), item_name="verbose")
+
+    if verbose is None:
+        verbose = logging.WARNING
+    elif isinstance(verbose, str):
+        verbose = verbose.upper()
+        _check_value(verbose, logging_types, item_name="verbose")
+        verbose = logging_types[verbose]
+    elif isinstance(verbose, bool):
+        if verbose:
+            verbose = logging.INFO
+        else:
+            verbose = logging.WARNING
+    elif isinstance(verbose, int):
+        verbose = _ensure_int(verbose)
+        if verbose <= 0:
+            raise ValueError(
+                "Argument 'verbose' can not be a negative integer, "
+                f"{verbose} is invalid."
+            )
+
+    return verbose

--- a/pycrostates/utils/_docs.py
+++ b/pycrostates/utils/_docs.py
@@ -20,7 +20,6 @@ keys: Tuple[str, ...] = (
     "tmin_raw",
     "tmax_raw",
     "reject_by_annotation_raw",
-    "verbose",
 )
 
 for key in keys:
@@ -32,6 +31,16 @@ for key in keys:
     if ".. versionadded::" in entry:
         entry = entry.replace(".. versionadded::", ".. versionadded:: MNE ")
     docdict[key] = entry
+
+docdict[
+    "verbose"
+] = """
+verbose : int | str | bool | None
+    Sets the verbosity level. The verbosity increases gradually between
+    ``"CRITICAL"``, ``"ERROR"``, ``"WARNING"``, ``"INFO"`` and ``"DEBUG"``.
+    If None is provided, the verbosity is set to ``"WARNING"``.
+    If a bool is provided, the verbosity is set to ``"WARNING"`` for False and
+    to ``"INFO"`` for True."""
 
 # ---- Clusters ----
 docdict[

--- a/pycrostates/utils/_fixes.py
+++ b/pycrostates/utils/_fixes.py
@@ -1,0 +1,20 @@
+"""Temporary bug-fixes awaiting an upstream fix."""
+
+import sys
+
+
+# https://github.com/sphinx-gallery/sphinx-gallery/issues/1112
+class _WrapStdOut(object):
+    """Dynamically wrap to sys.stdout.
+
+    This makes packages that monkey-patch sys.stdout (e.g.doctest,
+    sphinx-gallery) work properly.
+    """
+
+    def __getattr__(self, name):  # noqa: D105
+        # Even more ridiculous than this class, this must be sys.stdout (not
+        # just stdout) in order for this to work (tested on OSX and Linux).
+        if hasattr(sys.stdout, name):
+            return getattr(sys.stdout, name)
+        else:
+            raise AttributeError(f"'file' object has not attribute '{name}'")

--- a/pycrostates/utils/_logs.py
+++ b/pycrostates/utils/_logs.py
@@ -5,7 +5,7 @@ from typing import Callable, Optional, Union
 
 import mne
 
-from ._checks import _check_type, check_verbose
+from ._checks import _check_type, _check_verbose
 from ._docs import fill_doc
 from ._fixes import _WrapStdOut
 
@@ -28,7 +28,7 @@ def _init_logger(
         The initialized logger.
     """
     # create logger
-    verbose = check_verbose(verbose)
+    verbose = _check_verbose(verbose)
     logger = logging.getLogger(__package__.split(".utils", maxsplit=1)[0])
     logger.propagate = False
     logger.setLevel(verbose)
@@ -61,7 +61,7 @@ def add_file_handler(
         If not None, encoding used to open the file.
     %(verbose)s
     """
-    verbose = check_verbose(verbose)
+    verbose = _check_verbose(verbose)
     handler = logging.FileHandler(fname, mode, encoding)
     handler.setFormatter(_LoggerFormatter())
     handler.setLevel(verbose)
@@ -81,7 +81,7 @@ def set_log_level(
         If True, also changes the log level of MNE.
     """
     _check_type(apply_to_mne, (bool,), "apply_to_mne")
-    verbose = check_verbose(verbose)
+    verbose = _check_verbose(verbose)
     if apply_to_mne:
         mne.set_log_level(verbose)
     logger.setLevel(verbose)

--- a/pycrostates/utils/tests/test_checks.py
+++ b/pycrostates/utils/tests/test_checks.py
@@ -1,5 +1,6 @@
 """Test _checks.py"""
 
+import logging
 import os
 import re
 
@@ -21,6 +22,7 @@ from pycrostates.utils._checks import (
     _check_tmin_tmax,
     _check_type,
     _check_value,
+    _check_verbose,
     _ensure_int,
 )
 
@@ -239,3 +241,22 @@ def test_check_picks_uniqueness():
     picks = _picks_to_idx(info, [1, 2, 3])
     with pytest.raises(ValueError, match="Only one datatype can be selected"):
         _check_picks_uniqueness(info, picks)
+
+
+def test_check_verbose():
+    """Test check_verbose checker."""
+    # valids
+    assert _check_verbose(12) == 12
+    assert _check_verbose("INFO") == logging.INFO
+    assert _check_verbose("DEBUG") == logging.DEBUG
+    assert _check_verbose(True) == logging.INFO
+    assert _check_verbose(False) == logging.WARNING
+    assert _check_verbose(None) == logging.WARNING
+
+    # invalids
+    with pytest.raises(TypeError, match="must be an instance of"):
+        _check_verbose(("INFO",))
+    with pytest.raises(ValueError, match="Invalid value"):
+        _check_verbose("101")
+    with pytest.raises(ValueError, match="negative integer, -101 is invalid."):
+        _check_verbose(-101)

--- a/pycrostates/utils/tests/test_docs.py
+++ b/pycrostates/utils/tests/test_docs.py
@@ -2,8 +2,8 @@
 
 import pytest
 
-from .._docs import copy_doc, fill_doc
-from ..logs import verbose
+from pycrostates.utils._docs import copy_doc, fill_doc
+from pycrostates.utils._logs import verbose
 
 
 def test_fill_doc_function():

--- a/pycrostates/utils/tests/test_docs.py
+++ b/pycrostates/utils/tests/test_docs.py
@@ -1,37 +1,209 @@
 """Test _docs.py"""
 
-from pycrostates.utils._docs import copy_doc, fill_doc
+import pytest
+
+from .._docs import copy_doc, fill_doc
+from ..logs import verbose
 
 
-def test_fill_doc():
-    """Test decorator to fill docstring."""
+def test_fill_doc_function():
+    """Test decorator to fill docstring on functions."""
 
+    # test filling docstring
     @fill_doc
-    def foo(n_clusters, verbose):
+    def foo(verbose):
         """My doc.
 
         Parameters
         ----------
-        %(n_clusters)s
         %(verbose)s
         """
         pass
 
-    assert "n_clusters : int" in foo.__doc__
-    assert "verbose : bool" in foo.__doc__
+    assert "verbose : int | str | bool | None" in foo.__doc__
+
+    # test filling empty-docstring
+    @fill_doc
+    def foo():
+        pass
+
+    assert foo.__doc__ is None
+
+    # test filling docstring with invalid key
+    with pytest.raises(RuntimeError, match="Error documenting"):
+
+        @fill_doc
+        def foo(verbose):
+            """My doc.
+
+            Parameters
+            ----------
+            %(invalid_key)s
+            """
+            pass
+
+    # test filling docstring of decorated function
+    @fill_doc
+    @verbose
+    def foo(verbose=None):
+        """My doc.
+
+        Parameters
+        ----------
+        %(verbose)s
+        """
+        pass
+
+    assert "verbose : int | str | bool | None" in foo.__doc__
 
 
-def test_copy_doc():
-    """Test decorator to copy docstring."""
+def test_fill_doc_class():
+    """Test decorator to fill docstring on classes."""
 
+    @fill_doc
+    class Foo:
+        """My doc.
+
+        Parameters
+        ----------
+        %(verbose)s
+        """
+
+        def __init__(self, verbose=None):
+            pass
+
+        @fill_doc
+        def method(self, verbose=None):
+            """My method doc.
+
+            Parameters
+            ----------
+            %(verbose)s
+            """
+            pass
+
+        @fill_doc
+        @verbose
+        def method_decorated(self, verbose=None):
+            """My method doc.
+
+            Parameters
+            ----------
+            %(verbose)s
+            """
+            pass
+
+        @staticmethod
+        @fill_doc
+        @verbose
+        def method_decorated_static(verbose=None):
+            """My method doc.
+
+            Parameters
+            ----------
+            %(verbose)s
+            """
+            pass
+
+    assert "verbose : int | str | bool | None" in Foo.__doc__
+    assert "verbose : int | str | bool | None" in Foo.method.__doc__
+    assert "verbose : int | str | bool | None" in Foo.method_decorated.__doc__
+    assert "verbose : int" in Foo.method_decorated_static.__doc__
+    foo = Foo()
+    assert "verbose : int | str | bool | None" in foo.__doc__
+    assert "verbose : int | str | bool | None" in foo.method.__doc__
+    assert "verbose : int | str | bool | None" in foo.method_decorated.__doc__
+
+
+def test_copy_doc_function():
+    """Test decorator to copy docstring on functions."""
+
+    # test copy of docstring
     def foo(x, y):
-        """
-        My doc.
-        """
+        """My doc."""
         pass
 
     @copy_doc(foo)
     def foo2(x, y):
         pass
 
-    assert "My doc." in foo2.__doc__
+    @copy_doc(foo)
+    def foo3(x, y):
+        """Doc of foo3."""
+        pass
+
+    assert foo.__doc__ == foo2.__doc__
+    assert foo.__doc__ + "Doc of foo3." == foo3.__doc__
+
+    # test copy of docstring from a function without docstring
+    def foo(x, y):
+        pass
+
+    with pytest.raises(RuntimeError, match="The docstring from foo could not"):
+
+        @copy_doc(foo)
+        def foo2(x, y):
+            pass
+
+    # test copy docstring of decorated function
+    @verbose
+    def foo(verbose=None):
+        """My doc."""
+        pass
+
+    @copy_doc(foo)
+    def foo2(verbose=None):
+        pass
+
+    @copy_doc(foo)
+    @verbose
+    def foo3(verbose=None):
+        pass
+
+    assert foo.__doc__ == foo2.__doc__
+    assert foo.__doc__ == foo3.__doc__
+
+
+def test_copy_doc_class():
+    """Test decorator to copy docstring on classes."""
+
+    class Foo:
+        """My doc."""
+
+        def __init__(self):
+            pass
+
+        def method1(self):
+            """Super 101 doc."""
+            pass
+
+    @copy_doc(Foo)
+    class Foo2:
+        def __init__(self):
+            pass
+
+        @copy_doc(Foo.method1)
+        def method2(self):
+            pass
+
+        @copy_doc(Foo.method1)
+        @verbose
+        def method3(self, verbose=None):
+            pass
+
+        @staticmethod
+        @copy_doc(Foo.method1)
+        @verbose
+        def method4(verbose=None):
+            pass
+
+    assert Foo.__doc__ == Foo2.__doc__
+    assert Foo.method1.__doc__ == Foo2.method2.__doc__
+    assert Foo.method1.__doc__ == Foo2.method3.__doc__
+    assert Foo.method1.__doc__ == Foo2.method4.__doc__
+    foo = Foo()
+    foo2 = Foo2()
+    assert foo.__doc__ == foo2.__doc__
+    assert foo.method1.__doc__ == foo2.method2.__doc__
+    assert foo.method1.__doc__ == foo2.method3.__doc__
+    assert foo.method1.__doc__ == foo2.method4.__doc__

--- a/pycrostates/utils/tests/test_logs.py
+++ b/pycrostates/utils/tests/test_logs.py
@@ -5,13 +5,20 @@ from typing import Optional, Union
 
 import pytest
 
-from .._logs import add_file_handler, logger, set_log_level, verbose
+from pycrostates.utils._logs import (
+    add_file_handler,
+    logger,
+    set_log_level,
+    verbose,
+)
 
 logger.propagate = True
 
 
 def test_default_log_level(caplog):
     """Test the default log level."""
+    set_log_level("WARNING")  # set to default
+
     caplog.clear()
     logger.debug("101")
     assert "101" not in caplog.text

--- a/pycrostates/utils/tests/test_logs.py
+++ b/pycrostates/utils/tests/test_logs.py
@@ -1,0 +1,143 @@
+"""Test _logs.py"""
+
+import logging
+from typing import Optional, Union
+
+import pytest
+
+from .._logs import add_file_handler, logger, set_log_level, verbose
+
+logger.propagate = True
+
+
+def test_default_log_level(caplog):
+    """Test the default log level."""
+    caplog.clear()
+    logger.debug("101")
+    assert "101" not in caplog.text
+
+    caplog.clear()
+    logger.info("101")
+    assert "101" not in caplog.text
+
+    caplog.clear()
+    logger.warning("101")
+    assert "101" in caplog.text
+
+    caplog.clear()
+    logger.error("101")
+    assert "101" in caplog.text
+
+    caplog.clear()
+    logger.critical("101")
+    assert "101" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "level", ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
+)
+def test_logger(level, caplog):
+    """Test basic logger functionalities."""
+    level_functions = {
+        "DEBUG": logger.debug,
+        "INFO": logger.info,
+        "WARNING": logger.warning,
+        "ERROR": logger.error,
+        "CRITICAL": logger.critical,
+    }
+    level_int = {
+        "DEBUG": logging.DEBUG,
+        "INFO": logging.INFO,
+        "WARNING": logging.WARNING,
+        "ERROR": logging.ERROR,
+        "CRITICAL": logging.CRITICAL,
+    }
+    set_log_level(level)
+
+    for level_, function in level_functions.items():
+        caplog.clear()
+        function("101")
+        if level_int[level] <= level_int[level_]:
+            assert "101" in caplog.text
+        else:
+            assert "101" not in caplog.text
+
+
+def test_verbose(caplog):
+    """Test verbose decorator."""
+
+    # function
+    @verbose
+    def foo(verbose: Optional[Union[bool, str, int]] = None):
+        """Foo function."""
+        logger.debug("101")
+
+    assert foo.__doc__ == "Foo function."
+    assert foo.__name__ == "foo"
+    set_log_level("INFO")
+    caplog.clear()
+    foo()
+    assert "101" not in caplog.text
+
+    for level in (20, 25, 30, True, False, "WARNING", "ERROR"):
+        caplog.clear()
+        foo(verbose=level)
+        assert "101" not in caplog.text
+
+    caplog.clear()
+    foo(verbose="DEBUG")
+    assert "101" in caplog.text
+    assert logger.level == logging.INFO
+
+    # method
+    class Foo:
+        def __init__(self):
+            pass
+
+        @verbose
+        def foo(self, verbose: Optional[Union[bool, str, int]] = None):
+            logger.debug("101")
+
+        @staticmethod
+        @verbose
+        def foo2(verbose: Optional[Union[bool, str, int]] = None):
+            logger.debug("101")
+
+    foo = Foo()
+    set_log_level("INFO")
+    caplog.clear()
+    foo.foo()
+    assert "101" not in caplog.text
+    caplog.clear()
+    foo.foo(verbose="DEBUG")
+    assert "101" in caplog.text
+
+    # static method
+    caplog.clear()
+    Foo.foo2()
+    assert "101" not in caplog.text
+    caplog.clear()
+    Foo.foo2(verbose="DEBUG")
+    assert "101" in caplog.text
+
+
+def test_file_handler(tmp_path):
+    """Test adding a file handler."""
+    fname = tmp_path / "logs.txt"
+    add_file_handler(fname)  # default level: WARNING.
+
+    logger.warning("test1")
+    logger.info("test2")
+    logger.handlers[-1].setLevel(logging.INFO)
+    logger.info("test3")
+
+    logger.handlers[-1].close()
+
+    with open(fname, mode="r") as file:
+        lines = file.readlines()
+
+    assert len(lines) == 2
+    assert "test1" in lines[0]
+    assert "test2" not in lines[0]
+    assert "test2" not in lines[1]
+    assert "test3" in lines[1]

--- a/pycrostates/viz/segmentation.py
+++ b/pycrostates/viz/segmentation.py
@@ -13,7 +13,7 @@ from numpy.typing import NDArray
 
 from ..utils._checks import _check_type
 from ..utils._docs import fill_doc
-from ..utils._logs import _set_verbose, logger
+from ..utils._logs import logger, verbose
 
 
 @fill_doc
@@ -195,6 +195,7 @@ def plot_epoch_segmentation(
     return fig
 
 
+@verbose
 def _plot_segmentation(
     labels: NDArray[int],
     gfp: NDArray[float],
@@ -209,7 +210,6 @@ def _plot_segmentation(
     **kwargs,
 ):
     """Code snippet to plot segmentation for raw and epochs."""
-    _set_verbose(verbose)
     _check_type(labels, (np.ndarray,), "labels")  # 1D array (n_times, )
     _check_type(gfp, (np.ndarray,), "gfp")  # 1D array (n_times, )
     _check_type(times, (np.ndarray,), "times")  # 1D array (n_times, )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,25 @@ match-dir = '^(?!docs|tutorials|build|dist|\.).*'
 add_ignore = 'D100,D104,D107'
 
 [tool.pytest.ini_options]
+minversion = '6.0'
+addopts = '--durations 20 --junit-xml=junit-results.xml --verbose'
 filterwarnings = [
     "ignore:Matplotlib is currently using agg:UserWarning",
 ]
+
+[tool.coverage.run]
+branch = true
+cover_pylib = false
+omit = [
+    '**/__init__.py',
+    '**/pycrostates/_version.py',
+    '**/pycrostates/utils/_fixes.py',
+    '**/tests/**',
+]
+
+[tool.coverage.report]
+exclude_lines = [
+    'pragma: no cover',
+    'if __name__ == .__main__.:',
+]
+precision = 2


### PR DESCRIPTION
Not sure why, but it took me this week to look more into how the logger works. Learned a lot, and also found several bugs/improvements to fix.

e.g.
- Forward `__name__` and `__doc__` from the function wrapped by `@verbose`, which fixes the behavior of `fill_doc` and `copy_doc` when used with `@verbose`
- Fix how the handler log level is set
- Set the default handler log level to NOTSET, which sets it equal to the logger level
- Wrap around `sys.stdout` to fix log capture by `sphinx-gallery`
- ...