### PR TITLE
Add support for array-like in _check_type

### DIFF
--- a/pycrostates/utils/_checks.py
+++ b/pycrostates/utils/_checks.py
@@ -4,6 +4,7 @@ import logging
 import multiprocessing as mp
 import operator
 import os
+from collections.abc import Sequence
 from itertools import product
 from pathlib import Path
 from typing import Any
@@ -71,6 +72,7 @@ _types = {
     "path-like": (str, Path, os.PathLike),
     "int": (_IntLike(),),
     "callable": (_Callable(),),
+    "array-like": (Sequence, np.ndarray),
 }
 
 

--- a/pycrostates/utils/tests/test_checks.py
+++ b/pycrostates/utils/tests/test_checks.py
@@ -48,13 +48,9 @@ def test_check_type():
         pass
 
     _check_type(foo_function, ("callable",))
-    _check_type(101, ("numeric",))
-    _check_type(101.0, ("numeric",))
     _check_type((1, 0, 1), ("array-like",))
     _check_type([1, 0, 1], ("array-like",))
     _check_type(np.array([1, 0, 1]), ("array-like",))
-
-
     assert _check_type(101, ("numeric",)) == 101
     assert _check_type(101.0, ("numeric",)) == 101.0
 

--- a/pycrostates/utils/tests/test_checks.py
+++ b/pycrostates/utils/tests/test_checks.py
@@ -48,6 +48,12 @@ def test_check_type():
         pass
 
     _check_type(foo_function, ("callable",))
+    _check_type(101, ("numeric",))
+    _check_type(101.0, ("numeric",))
+    _check_type((1, 0, 1), ("array-like",))
+    _check_type([1, 0, 1], ("array-like",))
+    _check_type(np.array([1, 0, 1]), ("array-like",))
+
 
     assert _check_type(101, ("numeric",)) == 101
     assert _check_type(101.0, ("numeric",)) == 101.0
@@ -55,6 +61,8 @@ def test_check_type():
     # invalids
     with pytest.raises(TypeError, match="Item must be an instance of"):
         _check_type(101, (float,))
+    with pytest.raises(TypeError, match="Item must be an instance of"):
+        _check_type(101, ("array-like",))
     with pytest.raises(TypeError, match="'number' must be an instance of"):
         _check_type(101, (float,), "number")
 


### PR DESCRIPTION
Short update following a PR in MNE, `Sequence` to capture all array-like types is quite useful!