### PR TITLE
Use assert_allclose instead of np.allclose and np.isclose(...).all()

### DIFF
--- a/pycrostates/cluster/tests/test_aahc.py
+++ b/pycrostates/cluster/tests/test_aahc.py
@@ -267,22 +267,22 @@ def test_aahClusterMeans():
     # Test copy
     aahCluster2 = aahCluster1.copy()
     _check_fitted(aahCluster2)
-    assert np.isclose(
+    assert_allclose(
         aahCluster2._cluster_centers_, aahCluster1._cluster_centers_
-    ).all()
+    )
     assert np.isclose(aahCluster2.GEV_, aahCluster1.GEV_)
-    assert np.isclose(aahCluster2._labels_, aahCluster1._labels_).all()
+    assert_allclose(aahCluster2._labels_, aahCluster1._labels_)
     aahCluster2.fitted = False
     _check_fitted(aahCluster1)
     _check_unfitted(aahCluster2)
 
     aahCluster3 = aahCluster1.copy(deep=False)
     _check_fitted(aahCluster3)
-    assert np.isclose(
+    assert_allclose(
         aahCluster3._cluster_centers_, aahCluster1._cluster_centers_
-    ).all()
+    )
     assert np.isclose(aahCluster3.GEV_, aahCluster1.GEV_)
-    assert np.isclose(aahCluster3._labels_, aahCluster1._labels_).all()
+    assert_allclose(aahCluster3._labels_, aahCluster1._labels_)
     aahCluster3.fitted = False
     _check_fitted(aahCluster1)
     _check_unfitted(aahCluster3)
@@ -314,52 +314,52 @@ def test_invert_polarity():
     aahCluster_ = aah_cluster.copy()
     cluster_centers_ = deepcopy(aahCluster_._cluster_centers_)
     aahCluster_.invert_polarity([True, False, True, False])
-    assert np.isclose(
+    assert_allclose(
         aahCluster_._cluster_centers_[0, :], -cluster_centers_[0, :]
-    ).all()
-    assert np.isclose(
+    )
+    assert_allclose(
         aahCluster_._cluster_centers_[1, :], cluster_centers_[1, :]
-    ).all()
-    assert np.isclose(
+    )
+    assert_allclose(
         aahCluster_._cluster_centers_[2, :], -cluster_centers_[2, :]
-    ).all()
-    assert np.isclose(
+    )
+    assert_allclose(
         aahCluster_._cluster_centers_[3, :], cluster_centers_[3, :]
-    ).all()
+    )
 
     # bool
     aahCluster_ = aah_cluster.copy()
     cluster_centers_ = deepcopy(aahCluster_._cluster_centers_)
     aahCluster_.invert_polarity(True)
-    assert np.isclose(
+    assert_allclose(
         aahCluster_._cluster_centers_[0, :], -cluster_centers_[0, :]
-    ).all()
-    assert np.isclose(
+    )
+    assert_allclose(
         aahCluster_._cluster_centers_[1, :], -cluster_centers_[1, :]
-    ).all()
-    assert np.isclose(
+    )
+    assert_allclose(
         aahCluster_._cluster_centers_[2, :], -cluster_centers_[2, :]
-    ).all()
-    assert np.isclose(
+    )
+    assert_allclose(
         aahCluster_._cluster_centers_[3, :], -cluster_centers_[3, :]
-    ).all()
+    )
 
     # np.array
     aahCluster_ = aah_cluster.copy()
     cluster_centers_ = deepcopy(aahCluster_._cluster_centers_)
     aahCluster_.invert_polarity(np.array([True, False, True, False]))
-    assert np.isclose(
+    assert_allclose(
         aahCluster_._cluster_centers_[0, :], -cluster_centers_[0, :]
-    ).all()
-    assert np.isclose(
+    )
+    assert_allclose(
         aahCluster_._cluster_centers_[1, :], cluster_centers_[1, :]
-    ).all()
-    assert np.isclose(
+    )
+    assert_allclose(
         aahCluster_._cluster_centers_[2, :], -cluster_centers_[2, :]
-    ).all()
-    assert np.isclose(
+    )
+    assert_allclose(
         aahCluster_._cluster_centers_[3, :], cluster_centers_[3, :]
-    ).all()
+    )
 
     # Test invalid arguments
     with pytest.raises(ValueError, match="not a 2D iterable"):
@@ -450,37 +450,37 @@ def test_reorder(caplog):
     # Test mapping
     aahCluster_ = aah_cluster.copy()
     aahCluster_.reorder_clusters(mapping={0: 1})
-    assert np.isclose(
+    assert_allclose(
         aah_cluster._cluster_centers_[0, :],
         aahCluster_._cluster_centers_[1, :],
-    ).all()
-    assert np.isclose(
+    )
+    assert_allclose(
         aah_cluster._cluster_centers_[1, :],
         aahCluster_._cluster_centers_[0, :],
-    ).all()
+    )
     assert aah_cluster._cluster_names[0] == aahCluster_._cluster_names[1]
     assert aah_cluster._cluster_names[0] == aahCluster_._cluster_names[1]
 
     # Test order
     aahCluster_ = aah_cluster.copy()
     aahCluster_.reorder_clusters(order=[1, 0, 2, 3])
-    assert np.isclose(
+    assert_allclose(
         aah_cluster._cluster_centers_[0], aahCluster_._cluster_centers_[1]
-    ).all()
-    assert np.isclose(
+    )
+    assert_allclose(
         aah_cluster._cluster_centers_[1], aahCluster_._cluster_centers_[0]
-    ).all()
+    )
     assert aah_cluster._cluster_names[0] == aahCluster_._cluster_names[1]
     assert aah_cluster._cluster_names[0] == aahCluster_._cluster_names[1]
 
     aahCluster_ = aah_cluster.copy()
     aahCluster_.reorder_clusters(order=np.array([1, 0, 2, 3]))
-    assert np.isclose(
+    assert_allclose(
         aah_cluster._cluster_centers_[0], aahCluster_._cluster_centers_[1]
-    ).all()
-    assert np.isclose(
+    )
+    assert_allclose(
         aah_cluster._cluster_centers_[1], aahCluster_._cluster_centers_[0]
-    ).all()
+    )
     assert aah_cluster._cluster_names[0] == aahCluster_._cluster_names[1]
     assert aah_cluster._cluster_names[0] == aahCluster_._cluster_names[1]
 
@@ -783,14 +783,14 @@ def test_fit_data_shapes():
     aahCluster_reject_omit.fit(raw_, reject_by_annotation="omit")
 
     # Compare 'omit' and True
-    assert np.isclose(
+    assert_allclose(
         aahCluster_reject_omit._fitted_data,
         aahCluster_reject_True._fitted_data,
-    ).all()
+    )
     assert np.isclose(aahCluster_reject_omit.GEV_, aahCluster_reject_True.GEV_)
-    assert np.isclose(
+    assert_allclose(
         aahCluster_reject_omit._labels_, aahCluster_reject_True._labels_
-    ).all()
+    )
     # due to internal randomness, the sign can be flipped
     sgn = np.sign(
         np.sum(
@@ -800,10 +800,10 @@ def test_fit_data_shapes():
         )
     )
     aahCluster_reject_True._cluster_centers_ *= sgn[:, None]
-    assert np.isclose(
+    assert_allclose(
         aahCluster_reject_omit._cluster_centers_,
         aahCluster_reject_True._cluster_centers_,
-    ).all()
+    )
 
     # Make sure there is a shape diff between True and False
     assert (
@@ -835,9 +835,9 @@ def test_fit_data_shapes():
         aahCluster_rej_5_end._fitted_data, raw_, "eeg", 5, None, "omit"
     )
     assert aahCluster_rej_0_5._fitted_data.shape != fitted_data_0_5.shape
-    assert np.isclose(
+    assert_allclose(
         fitted_data_5_end, aahCluster_rej_5_end._fitted_data
-    ).all()
+    )
 
 
 def test_refit():
@@ -966,15 +966,18 @@ def test_predict_default(caplog):
     segmentation_no_annot = aah_cluster.predict(
         raw_eeg, factor=0, reject_edges=True, reject_by_annotation="omit"
     )
-    assert not np.isclose(
-        segmentation_rej_True._labels, segmentation_rej_False._labels
-    ).all()
-    assert np.isclose(
+    assert not np.allclose(
+        segmentation_rej_True._labels,
+        segmentation_rej_False._labels,
+        rtol=1e-7,
+        atol=0,
+    )
+    assert_allclose(
         segmentation_no_annot._labels, segmentation_rej_False._labels
-    ).all()
-    assert np.isclose(
+    )
+    assert_allclose(
         segmentation_rej_None._labels, segmentation_rej_False._labels
-    ).all()
+    )
 
     # test different half_window_size
     segmentation1 = aah_cluster.predict(
@@ -986,9 +989,15 @@ def test_predict_default(caplog):
     segmentation3 = aah_cluster.predict(
         raw_eeg, factor=0, reject_edges=False, half_window_size=3
     )
-    assert not np.isclose(segmentation1._labels, segmentation2._labels).all()
-    assert not np.isclose(segmentation1._labels, segmentation3._labels).all()
-    assert not np.isclose(segmentation2._labels, segmentation3._labels).all()
+    assert not np.allclose(
+        segmentation1._labels, segmentation2._labels, rtol=1e-7, atol=0
+    )
+    assert not np.allclose(
+        segmentation1._labels, segmentation3._labels, rtol=1e-7, atol=0
+    )
+    assert not np.allclose(
+        segmentation2._labels, segmentation3._labels, rtol=1e-7, atol=0
+    )
 
 
 # pylint: enable=too-many-statements

--- a/pycrostates/cluster/tests/test_aahc.py
+++ b/pycrostates/cluster/tests/test_aahc.py
@@ -14,6 +14,7 @@ from mne.channels import DigMontage
 from mne.datasets import testing
 from mne.io import RawArray, read_raw_fif
 from mne.io.pick import _picks_to_idx
+from numpy.testing import assert_allclose
 
 from pycrostates import __version__
 from pycrostates.cluster import AAHCluster
@@ -870,7 +871,7 @@ def test_refit():
     with pytest.raises(RuntimeError, match="must be unfitted"):
         aahCluster_.fit(raw, picks="mag")  # works
     assert eeg_ch_names == aahCluster_.info["ch_names"]
-    assert np.allclose(eeg_cluster_centers, aahCluster_.cluster_centers_)
+    assert_allclose(eeg_cluster_centers, aahCluster_.cluster_centers_)
 
 
 # pylint: disable=too-many-statements
@@ -1281,9 +1282,9 @@ def test_save(tmp_path, caplog):
     segmentation1 = aahCluster1.predict(raw_eeg, picks="eeg")
     segmentation2 = aahCluster2.predict(raw_eeg, picks="eeg")
 
-    assert np.allclose(segmentation._labels, segmentation1._labels)
-    assert np.allclose(segmentation._labels, segmentation2._labels)
-    assert np.allclose(segmentation1._labels, segmentation2._labels)
+    assert_allclose(segmentation._labels, segmentation1._labels)
+    assert_allclose(segmentation._labels, segmentation2._labels)
+    assert_allclose(segmentation1._labels, segmentation2._labels)
 
 
 def test_comparison(caplog):

--- a/pycrostates/cluster/tests/test_kmeans.py
+++ b/pycrostates/cluster/tests/test_kmeans.py
@@ -14,6 +14,7 @@ from mne.channels import DigMontage
 from mne.datasets import testing
 from mne.io import RawArray, read_raw_fif
 from mne.io.pick import _picks_to_idx
+from numpy.testing import assert_allclose
 
 from pycrostates import __version__
 from pycrostates.cluster import ModKMeans
@@ -434,7 +435,7 @@ def test_reorder(caplog):
     ModK__ = ModK_.copy()
     ModK_.reorder_clusters(order=np.array([1, 0, 2, 3]))
     ModK_.reorder_clusters(template=ModK__)
-    assert np.allclose(ModK_.cluster_centers_, ModK_.cluster_centers_)
+    assert_allclose(ModK_.cluster_centers_, ModK_.cluster_centers_)
 
 
 def test_properties(caplog):
@@ -1260,9 +1261,9 @@ def test_save(tmp_path, caplog):
     segmentation1 = ModK1.predict(raw_eeg, picks="eeg")
     segmentation2 = ModK2.predict(raw_eeg, picks="eeg")
 
-    assert np.allclose(segmentation._labels, segmentation1._labels)
-    assert np.allclose(segmentation._labels, segmentation2._labels)
-    assert np.allclose(segmentation1._labels, segmentation2._labels)
+    assert_allclose(segmentation._labels, segmentation1._labels)
+    assert_allclose(segmentation._labels, segmentation2._labels)
+    assert_allclose(segmentation1._labels, segmentation2._labels)
 
 
 def test_comparison(caplog):

--- a/pycrostates/cluster/tests/test_kmeans.py
+++ b/pycrostates/cluster/tests/test_kmeans.py
@@ -160,18 +160,18 @@ def test_ModKMeans():
     # Test copy
     ModK2 = ModK1.copy()
     _check_fitted(ModK2)
-    assert np.isclose(ModK2._cluster_centers_, ModK1._cluster_centers_).all()
+    assert_allclose(ModK2._cluster_centers_, ModK1._cluster_centers_)
     assert np.isclose(ModK2.GEV_, ModK1.GEV_)
-    assert np.isclose(ModK2._labels_, ModK1._labels_).all()
+    assert_allclose(ModK2._labels_, ModK1._labels_)
     ModK2.fitted = False
     _check_fitted(ModK1)
     _check_unfitted(ModK2)
 
     ModK3 = ModK1.copy(deep=False)
     _check_fitted(ModK3)
-    assert np.isclose(ModK3._cluster_centers_, ModK1._cluster_centers_).all()
+    assert_allclose(ModK3._cluster_centers_, ModK1._cluster_centers_)
     assert np.isclose(ModK3.GEV_, ModK1.GEV_)
-    assert np.isclose(ModK3._labels_, ModK1._labels_).all()
+    assert_allclose(ModK3._labels_, ModK1._labels_)
     ModK3.fitted = False
     _check_fitted(ModK1)
     _check_unfitted(ModK3)
@@ -203,52 +203,52 @@ def test_invert_polarity():
     ModK_ = ModK.copy()
     cluster_centers_ = deepcopy(ModK_._cluster_centers_)
     ModK_.invert_polarity([True, False, True, False])
-    assert np.isclose(
+    assert_allclose(
         ModK_._cluster_centers_[0, :], -cluster_centers_[0, :]
-    ).all()
-    assert np.isclose(
+    )
+    assert_allclose(
         ModK_._cluster_centers_[1, :], cluster_centers_[1, :]
-    ).all()
-    assert np.isclose(
+    )
+    assert_allclose(
         ModK_._cluster_centers_[2, :], -cluster_centers_[2, :]
-    ).all()
-    assert np.isclose(
+    )
+    assert_allclose(
         ModK_._cluster_centers_[3, :], cluster_centers_[3, :]
-    ).all()
+    )
 
     # bool
     ModK_ = ModK.copy()
     cluster_centers_ = deepcopy(ModK_._cluster_centers_)
     ModK_.invert_polarity(True)
-    assert np.isclose(
+    assert_allclose(
         ModK_._cluster_centers_[0, :], -cluster_centers_[0, :]
-    ).all()
-    assert np.isclose(
+    )
+    assert_allclose(
         ModK_._cluster_centers_[1, :], -cluster_centers_[1, :]
-    ).all()
-    assert np.isclose(
+    )
+    assert_allclose(
         ModK_._cluster_centers_[2, :], -cluster_centers_[2, :]
-    ).all()
-    assert np.isclose(
+    )
+    assert_allclose(
         ModK_._cluster_centers_[3, :], -cluster_centers_[3, :]
-    ).all()
+    )
 
     # np.array
     ModK_ = ModK.copy()
     cluster_centers_ = deepcopy(ModK_._cluster_centers_)
     ModK_.invert_polarity(np.array([True, False, True, False]))
-    assert np.isclose(
+    assert_allclose(
         ModK_._cluster_centers_[0, :], -cluster_centers_[0, :]
-    ).all()
-    assert np.isclose(
+    )
+    assert_allclose(
         ModK_._cluster_centers_[1, :], cluster_centers_[1, :]
-    ).all()
-    assert np.isclose(
+    )
+    assert_allclose(
         ModK_._cluster_centers_[2, :], -cluster_centers_[2, :]
-    ).all()
-    assert np.isclose(
+    )
+    assert_allclose(
         ModK_._cluster_centers_[3, :], cluster_centers_[3, :]
-    ).all()
+    )
 
     # Test invalid arguments
     with pytest.raises(ValueError, match="not a 2D iterable"):
@@ -335,35 +335,35 @@ def test_reorder(caplog):
     # Test mapping
     ModK_ = ModK.copy()
     ModK_.reorder_clusters(mapping={0: 1})
-    assert np.isclose(
+    assert_allclose(
         ModK._cluster_centers_[0, :], ModK_._cluster_centers_[1, :]
-    ).all()
-    assert np.isclose(
+    )
+    assert_allclose(
         ModK._cluster_centers_[1, :], ModK_._cluster_centers_[0, :]
-    ).all()
+    )
     assert ModK._cluster_names[0] == ModK_._cluster_names[1]
     assert ModK._cluster_names[0] == ModK_._cluster_names[1]
 
     # Test order
     ModK_ = ModK.copy()
     ModK_.reorder_clusters(order=[1, 0, 2, 3])
-    assert np.isclose(
+    assert_allclose(
         ModK._cluster_centers_[0], ModK_._cluster_centers_[1]
-    ).all()
-    assert np.isclose(
+    )
+    assert_allclose(
         ModK._cluster_centers_[1], ModK_._cluster_centers_[0]
-    ).all()
+    )
     assert ModK._cluster_names[0] == ModK_._cluster_names[1]
     assert ModK._cluster_names[0] == ModK_._cluster_names[1]
 
     ModK_ = ModK.copy()
     ModK_.reorder_clusters(order=np.array([1, 0, 2, 3]))
-    assert np.isclose(
+    assert_allclose(
         ModK._cluster_centers_[0], ModK_._cluster_centers_[1]
-    ).all()
-    assert np.isclose(
+    )
+    assert_allclose(
         ModK._cluster_centers_[1], ModK_._cluster_centers_[0]
-    ).all()
+    )
     assert ModK._cluster_names[0] == ModK_._cluster_names[1]
     assert ModK._cluster_names[0] == ModK_._cluster_names[1]
 
@@ -699,16 +699,16 @@ def test_fit_data_shapes():
     ModK_reject_omit.fit(raw_, n_jobs=1, reject_by_annotation="omit")
 
     # Compare 'omit' and True
-    assert np.isclose(
+    assert_allclose(
         ModK_reject_omit._fitted_data, ModK_reject_True._fitted_data
-    ).all()
+    )
     assert np.isclose(ModK_reject_omit.GEV_, ModK_reject_True.GEV_)
-    assert np.isclose(
+    assert_allclose(
         ModK_reject_omit._labels_, ModK_reject_True._labels_
-    ).all()
-    assert np.isclose(
+    )
+    assert_allclose(
         ModK_reject_omit._cluster_centers_, ModK_reject_True._cluster_centers_
-    ).all()
+    )
 
     # Make sure there is a shape diff between True and False
     assert (
@@ -740,7 +740,7 @@ def test_fit_data_shapes():
         ModK_rej_5_end._fitted_data, raw_, "eeg", 5, None, "omit"
     )
     assert ModK_rej_0_5._fitted_data.shape != fitted_data_0_5.shape
-    assert np.isclose(fitted_data_5_end, ModK_rej_5_end._fitted_data).all()
+    assert_allclose(fitted_data_5_end, ModK_rej_5_end._fitted_data)
 
 
 def test_refit():
@@ -778,7 +778,7 @@ def test_refit():
     with pytest.raises(RuntimeError, match="must be unfitted"):
         ModK_.fit(raw, picks="mag")  # works
     assert eeg_ch_names == ModK_.info["ch_names"]
-    assert np.isclose(eeg_cluster_centers, ModK_.cluster_centers_).all()
+    assert_allclose(eeg_cluster_centers, ModK_.cluster_centers_)
 
 
 def test_predict_default(caplog):
@@ -870,15 +870,18 @@ def test_predict_default(caplog):
     segmentation_no_annot = ModK.predict(
         raw_eeg, factor=0, reject_edges=True, reject_by_annotation="omit"
     )
-    assert not np.isclose(
-        segmentation_rej_True._labels, segmentation_rej_False._labels
-    ).all()
-    assert np.isclose(
+    assert not np.allclose(
+        segmentation_rej_True._labels,
+        segmentation_rej_False._labels,
+        rtol=1e-7,
+        atol=0,
+    )
+    assert_allclose(
         segmentation_no_annot._labels, segmentation_rej_False._labels
-    ).all()
-    assert np.isclose(
+    )
+    assert_allclose(
         segmentation_rej_None._labels, segmentation_rej_False._labels
-    ).all()
+    )
 
     # test different half_window_size
     segmentation1 = ModK.predict(
@@ -890,9 +893,15 @@ def test_predict_default(caplog):
     segmentation3 = ModK.predict(
         raw_eeg, factor=0, reject_edges=False, half_window_size=3
     )
-    assert not np.isclose(segmentation1._labels, segmentation2._labels).all()
-    assert not np.isclose(segmentation1._labels, segmentation3._labels).all()
-    assert not np.isclose(segmentation2._labels, segmentation3._labels).all()
+    assert not np.allclose(
+        segmentation1._labels, segmentation2._labels, rtol=1e-7, atol=0
+    )
+    assert not np.allclose(
+        segmentation1._labels, segmentation3._labels, rtol=1e-7, atol=0
+    )
+    assert not np.allclose(
+        segmentation2._labels, segmentation3._labels, rtol=1e-7, atol=0
+    )
 
 
 def test_picks_fit_predict(caplog):
@@ -1106,9 +1115,9 @@ def test_n_jobs():
     )
     ModK_.fit(raw_eeg, n_jobs=2)
     _check_fitted(ModK_)
-    assert np.isclose(ModK_._cluster_centers_, ModK._cluster_centers_).all()
+    assert_allclose(ModK_._cluster_centers_, ModK._cluster_centers_)
     assert np.isclose(ModK_.GEV_, ModK.GEV_)
-    assert np.isclose(ModK_._labels_, ModK._labels_).all()
+    assert_allclose(ModK_._labels_, ModK._labels_)
 
 
 def test_fit_not_converged(caplog):
@@ -1176,10 +1185,10 @@ def test_randomseed():
     )
     ModK3.fit(raw_eeg, n_jobs=1)
 
-    assert np.isclose(ModK1._cluster_centers_, ModK2._cluster_centers_).all()
-    assert not np.isclose(
-        ModK1._cluster_centers_, ModK3._cluster_centers_
-    ).all()
+    assert_allclose(ModK1._cluster_centers_, ModK2._cluster_centers_)
+    assert not np.allclose(
+        ModK1._cluster_centers_, ModK3._cluster_centers_, rtol=1e-7, atol=0
+    )
 
 
 def test_contains_mixin():

--- a/pycrostates/cluster/utils/tests/test_utils.py
+++ b/pycrostates/cluster/utils/tests/test_utils.py
@@ -3,6 +3,7 @@
 import numpy as np
 from mne.datasets import testing
 from mne.io import read_raw_fif
+from numpy.testing import assert_allclose
 
 from pycrostates.cluster import ModKMeans
 from pycrostates.cluster.utils.utils import _optimize_order, optimize_order
@@ -46,13 +47,13 @@ def test__optimize_order():
     current = random_template
     ignore_polarity = False
     order = _optimize_order(current, template, ignore_polarity=ignore_polarity)
-    assert np.allclose(current[order], template)
+    assert_allclose(current[order], template)
 
     # Shuffle + ignore_polarity
     current = random_template
     ignore_polarity = True
     order = _optimize_order(current, template, ignore_polarity=ignore_polarity)
-    assert np.allclose(current[order], template)
+    assert_allclose(current[order], template)
 
     # Shuffle + sign + ignore_polarity
     current = random_pol_template

--- a/pycrostates/io/tests/test_ch_data.py
+++ b/pycrostates/io/tests/test_ch_data.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 from mne import create_info, pick_types
+from numpy.testing import assert_allclose
 
 from pycrostates.io import ChData, ChInfo
 
@@ -27,13 +28,13 @@ def test_ChData():
     """Test basic ChData functionalities."""
     # create from info
     ch_data = ChData(data, info.copy())
-    assert np.allclose(ch_data._data, data)
+    assert_allclose(ch_data._data, data)
     assert isinstance(ch_data.info, ChInfo)
     assert info.ch_names == ch_data.info.ch_names
 
     # create from chinfo
     ch_data = ChData(data, ch_info.copy())
-    assert np.allclose(ch_data._data, data)
+    assert_allclose(ch_data._data, data)
     assert isinstance(ch_data.info, ChInfo)
     assert ch_info.ch_names == ch_data.info.ch_names
 
@@ -51,14 +52,14 @@ def test_ChData():
     data_ = ch_data.get_data()
     data_[0, :] = 0.0
     assert not np.allclose(data_, data)
-    assert np.allclose(ch_data._data, data)
+    assert_allclose(ch_data._data, data)
 
     # test get_data() with picks
     data_ = ch_data.get_data(picks="eeg")
-    assert np.allclose(data_, data)
+    assert_allclose(data_, data)
     ch_data.info["bads"] = [ch_data.info["ch_names"][0]]
     data_ = ch_data.get_data(picks="eeg")
-    assert np.allclose(data_, data[1:, :])
+    assert_allclose(data_, data[1:, :])
 
     # test repr
     assert isinstance(ch_data.__repr__(), str)

--- a/pycrostates/io/tests/test_ch_data.py
+++ b/pycrostates/io/tests/test_ch_data.py
@@ -51,7 +51,7 @@ def test_ChData():
     # test that data is copied
     data_ = ch_data.get_data()
     data_[0, :] = 0.0
-    assert not np.allclose(data_, data)
+    assert not np.allclose(data_, data, rtol=1e-7, atol=0)
     assert_allclose(ch_data._data, data)
 
     # test get_data() with picks

--- a/pycrostates/io/tests/test_fiff.py
+++ b/pycrostates/io/tests/test_fiff.py
@@ -2,11 +2,11 @@
 
 import os
 
-import numpy as np
 import pytest
 from mne.datasets import testing
 from mne.io import read_raw_fif
 from mne.preprocessing import ICA
+from numpy.testing import assert_allclose
 
 from pycrostates import __version__
 from pycrostates.cluster import ModKMeans
@@ -90,9 +90,9 @@ def test_write_and_read(tmp_path, caplog):
     segmentation1 = ModK1.predict(raw2, picks="eeg")
     segmentation2 = ModK2.predict(raw2, picks="eeg")
 
-    assert np.allclose(segmentation._labels, segmentation1._labels)
-    assert np.allclose(segmentation._labels, segmentation2._labels)
-    assert np.allclose(segmentation1._labels, segmentation2._labels)
+    assert_allclose(segmentation._labels, segmentation1._labels)
+    assert_allclose(segmentation._labels, segmentation2._labels)
+    assert_allclose(segmentation1._labels, segmentation2._labels)
 
 
 def test_invalid_write(tmp_path):

--- a/pycrostates/io/tests/test_meas_info.py
+++ b/pycrostates/io/tests/test_meas_info.py
@@ -11,6 +11,7 @@ from mne.io import read_raw_fif
 from mne.io.constants import FIFF
 from mne.transforms import Transform
 from mne.utils import check_version
+from numpy.testing import assert_allclose
 
 from pycrostates.io import ChInfo
 from pycrostates.utils._logs import logger, set_log_level
@@ -265,12 +266,12 @@ def test_montage():
                 montage.get_positions()[key] == montage2.get_positions()[key]
             )
         elif isinstance(montage.get_positions()[key], np.ndarray):
-            assert np.allclose(
+            assert_allclose(
                 montage.get_positions()[key], montage2.get_positions()[key]
             )
         elif isinstance(montage.get_positions()[key], OrderedDict):
             for k, v in montage.get_positions()[key].items():
-                assert np.allclose(
+                assert_allclose(
                     montage.get_positions()[key][k],
                     montage2.get_positions()[key][k],
                 )

--- a/pycrostates/preprocessing/tests/test_resample.py
+++ b/pycrostates/preprocessing/tests/test_resample.py
@@ -6,6 +6,7 @@ import pytest
 from mne import BaseEpochs
 from mne.datasets import testing
 from mne.io.pick import _picks_to_idx
+from numpy.testing import assert_allclose
 
 from pycrostates.io import ChData
 from pycrostates.preprocessing import resample
@@ -151,4 +152,4 @@ def test_resample_random_state():
     resamples_1 = resample(raw, n_resamples=1, n_samples=500, random_state=42)[
         0
     ]
-    assert np.allclose(resamples_0._data, resamples_1._data)
+    assert_allclose(resamples_0._data, resamples_1._data)

--- a/pycrostates/segmentation/tests/test_segmentation.py
+++ b/pycrostates/segmentation/tests/test_segmentation.py
@@ -4,6 +4,7 @@ import pytest
 from mne import BaseEpochs, Epochs, make_fixed_length_events
 from mne.datasets import testing
 from mne.io import BaseRaw, read_raw_fif
+from numpy.testing import assert_allclose
 
 from pycrostates.cluster import ModKMeans
 from pycrostates.segmentation import EpochsSegmentation, RawSegmentation
@@ -66,9 +67,9 @@ def test_properties(ModK, inst, caplog):
     assert isinstance(predict_parameters, dict)
 
     cluster_centers_ -= 10
-    assert np.allclose(cluster_centers_, segmentation._cluster_centers_ - 10)
+    assert_allclose(cluster_centers_, segmentation._cluster_centers_ - 10)
     labels -= 10
-    assert np.allclose(labels, segmentation._labels - 10)
+    assert_allclose(labels, segmentation._labels - 10)
     predict_parameters["test"] = 10
     assert "test" not in segmentation._predict_parameters
 
@@ -308,11 +309,11 @@ def test_compute_transition_matrix_stat(ModK, inst):
         segmentation.compute_transition_matrix(stat="wrong")
     T = segmentation.compute_transition_matrix(stat="count")
     T = segmentation.compute_transition_matrix(stat="probability")
-    assert np.allclose(np.sum(T, axis=1), 1)
+    assert_allclose(np.sum(T, axis=1), 1)
     T = segmentation.compute_transition_matrix(stat="proportion")
-    assert np.allclose(np.sum(T, axis=1), 1)
+    assert_allclose(np.sum(T, axis=1), 1)
     T = segmentation.compute_transition_matrix(stat="percent")
-    assert np.allclose(np.sum(T, axis=1), 100)
+    assert_allclose(np.sum(T, axis=1), 100)
 
 
 def test_compute_expected_transition_matrix_Raw():
@@ -341,8 +342,8 @@ def test_compute_expected_transition_matrix_stat(ModK, inst):
     ):
         segmentation.compute_expected_transition_matrix(stat="count")
     T = segmentation.compute_expected_transition_matrix(stat="probability")
-    assert np.allclose(np.sum(T, axis=1), 1)
+    assert_allclose(np.sum(T, axis=1), 1)
     T = segmentation.compute_expected_transition_matrix(stat="proportion")
-    assert np.allclose(np.sum(T, axis=1), 1)
+    assert_allclose(np.sum(T, axis=1), 1)
     T = segmentation.compute_expected_transition_matrix(stat="percent")
-    assert np.allclose(np.sum(T, axis=1), 100)
+    assert_allclose(np.sum(T, axis=1), 100)

--- a/pycrostates/segmentation/tests/test_transitions.py
+++ b/pycrostates/segmentation/tests/test_transitions.py
@@ -2,6 +2,7 @@ import re
 
 import numpy as np
 import pytest
+from numpy.testing import assert_allclose
 
 from pycrostates.segmentation.transitions import (
     _check_labels_n_clusters,
@@ -82,7 +83,7 @@ def test_compute_transition_matrix(labels, ignore_self, T):
     )
     assert isinstance(T, np.ndarray)
     assert t.shape == (n_clusters, n_clusters)
-    assert np.allclose(t, T)
+    assert_allclose(t, T)
 
 
 def test_compute_expected_transition_matrix():
@@ -101,7 +102,7 @@ def test_compute_expected_transition_matrix():
     expected_T = _compute_expected_transition_matrix(
         labels, n_clusters, ignore_self=True, stat="probability"
     )
-    assert np.allclose(boostrap_T, expected_T, atol=1e-2)
+    assert_allclose(boostrap_T, expected_T, atol=1e-2)
 
     # case where 1 state is missing
     labels = np.random.randint(-1, 3, 500)
@@ -118,7 +119,7 @@ def test_compute_expected_transition_matrix():
     expected_T = _compute_expected_transition_matrix(
         labels, n_clusters, ignore_self=True, stat="probability"
     )
-    assert np.allclose(boostrap_T, expected_T, atol=1e-2)
+    assert_allclose(boostrap_T, expected_T, atol=1e-2)
 
 
 def test_check_labels_n_clusters():

--- a/pycrostates/viz/cluster_centers.py
+++ b/pycrostates/viz/cluster_centers.py
@@ -118,7 +118,7 @@ def plot_cluster_centers(
             raise ValueError(
                 "Argument 'cluster_centers' and 'axes' must contain the same "
                 f"number of clusters and Axes. Provided: {n_clusters} "
-                "microstates maps and {axes.size} axes."
+                f"microstates maps and {axes.size} axes."
             )
         figs = [ax.get_figure() for ax in axes.flatten()]
         if len(set(figs)) == 1:

--- a/pycrostates/viz/cluster_centers.py
+++ b/pycrostates/viz/cluster_centers.py
@@ -16,6 +16,13 @@ from ..utils._docs import fill_doc
 from ..utils._logs import logger, verbose
 
 
+_GRADIENT_KWARGS_DEFAULTS: Dict[str, str] = {
+    "color": "black",
+    "linestyle": "-",
+    "marker": "P",
+}
+
+
 @fill_doc
 @verbose
 def plot_cluster_centers(
@@ -24,11 +31,7 @@ def plot_cluster_centers(
     cluster_names: List[str] = None,
     axes: Optional[Union[Axes, NDArray[Axes]]] = None,
     show_gradient: Optional[bool] = False,
-    gradient_kwargs: Dict[str, Any] = {
-        "color": "black",
-        "linestyle": "-",
-        "marker": "P",
-    },
+    gradient_kwargs: Dict[str, Any] = _GRADIENT_KWARGS_DEFAULTS,
     *,
     block: bool = False,
     verbose: Optional[str] = None,
@@ -74,7 +77,7 @@ def plot_cluster_centers(
         (dict,),
         "gradient_kwargs",
     )
-    if gradient_kwargs is not None and not show_gradient:
+    if gradient_kwargs != _GRADIENT_KWARGS_DEFAULTS and not show_gradient:
         logger.warning(
             "The argument 'gradient_kwargs' has not effect when "
             "the argument 'show_gradient' is set to False."


### PR DESCRIPTION
Fixes #114 

Also change to `assert_allclose` which has a saner `atol=0` argument + better logging/error information when failing.
Waiting now for tests to run, check that everything is still green.

After, WDYT about changing black to the default 88 character per line to match MNE? (it's a bit annoying to change the ruler position in the IDE :wink:)