### PR TITLE
Remove legacy setup.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ['setuptools >= 61.0.0']
+requires = ['setuptools >= 64.0.0']
 build-backend = 'setuptools.build_meta'
 
 [project]

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-from setuptools import setup
-
-setup()


### PR DESCRIPTION
Not needed anymore with setuptools 64.0.0 supporting PEP 660 for editable installs.