### PR TITLE
Restore numpy 2.0 pip-pre pytest workflow

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -83,7 +83,7 @@ jobs:
           python -m pip install --progress-bar off --upgrade pip setuptools
           python -m pip install --progress-bar off .[test]
           python -m pip install --progress-bar off --upgrade git+https://github.com/mne-tools/mne-python
-          python -m pip install --progress-bar off --upgrade --pre --only-binary :all: -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --timeout=180 numpy scipy scikit-learn matplotlib
+          python -m pip install --progress-bar off --upgrade --pre --only-binary :all: -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --timeout=180 "numpy>=2.0.0.dev0" "scipy>=1.13.0.dev0" "scikit-learn>=1.5.dev0" matplotlib
       - name: Display system information
         run: pycrostates-sys_info --developer
       - name: Display MNE info

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -65,8 +65,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.11"]
-        pip-install: ["numpy scipy scikit-learn", "matplotlib"]
-    name: pip-pre - py${{ matrix.python-version }} - ${{ matrix.pip-install }}
+    name: pip pre-release - py${{ matrix.python-version }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -84,7 +83,7 @@ jobs:
           python -m pip install --progress-bar off --upgrade pip setuptools
           python -m pip install --progress-bar off .[test]
           python -m pip install --progress-bar off --upgrade git+https://github.com/mne-tools/mne-python
-          python -m pip install --progress-bar off --upgrade --pre --only-binary :all: -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --timeout=180 ${{ matrix.pip-install }}
+          python -m pip install --progress-bar off --upgrade --pre --only-binary :all: -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --timeout=180 numpy scipy scikit-learn matplotlib
       - name: Display system information
         run: pycrostates-sys_info --developer
       - name: Display MNE info

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -83,7 +83,7 @@ jobs:
           python -m pip install --progress-bar off --upgrade pip setuptools
           python -m pip install --progress-bar off .[test]
           python -m pip install --progress-bar off --upgrade git+https://github.com/mne-tools/mne-python
-          python -m pip install --progress-bar off --upgrade --pre --only-binary :all: -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --timeout=180 "numpy>=2.0.0.dev0" "scipy>=1.13.0.dev0" "scikit-learn>=1.5.dev0" matplotlib
+          python -m pip install --progress-bar off --upgrade --only-binary :all: -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --timeout=180 "numpy>=2.0.0.dev0" "scipy>=1.13.0.dev0" "scikit-learn>=1.5.dev0" matplotlib
       - name: Display system information
         run: pycrostates-sys_info --developer
       - name: Display MNE info

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -65,7 +65,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.11"]
-    name: pip pre-release - py${{ matrix.python-version }}
+        pip-install: ["numpy scipy scikit-learn", "matplotlib"]
+    name: pip-pre - py${{ matrix.python-version }} - ${{ matrix.pip-install }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -83,7 +84,7 @@ jobs:
           python -m pip install --progress-bar off --upgrade pip setuptools
           python -m pip install --progress-bar off .[test]
           python -m pip install --progress-bar off --upgrade git+https://github.com/mne-tools/mne-python
-          python -m pip install --progress-bar off --upgrade --pre --only-binary :all: -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --timeout=180 numpy scipy scikit-learn matplotlib
+          python -m pip install --progress-bar off --upgrade --pre --only-binary :all: -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --timeout=180 ${{ matrix.pip-install }}
       - name: Display system information
         run: pycrostates-sys_info --developer
       - name: Display MNE info

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -83,7 +83,9 @@ jobs:
           python -m pip install --progress-bar off --upgrade pip setuptools
           python -m pip install --progress-bar off .[test]
           python -m pip install --progress-bar off --upgrade git+https://github.com/mne-tools/mne-python
-          python -m pip install --progress-bar off --upgrade --only-binary :all: -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --timeout=180 "numpy>=2.0.0.dev0" "scipy>=1.13.0.dev0" "scikit-learn>=1.5.dev0" matplotlib
+          python -m pip install matplotlib
+          python -m pip install --progress-bar off --upgrade --no-deps --pre --only-binary :all: -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --timeout=180 matplotlib
+          python -m pip install --progress-bar off --upgrade --pre --only-binary :all: -i https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --timeout=180 numpy scipy scikit-learn
       - name: Display system information
         run: pycrostates-sys_info --developer
       - name: Display MNE info


### PR DESCRIPTION
The matplotlib nightly build are compiled against `numpy` stable and not `numpy 2.0` thus yielding an incompatibility between the jobs.