### PR TITLE
Add codecov token to workflow

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -61,6 +61,7 @@ jobs:
           files: ./coverage.xml
           flags: unittests  # optional
           name: codecov-umbrella  # optional
+          token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true  # optional (default = false)
 
   pytest-pip-pre:
@@ -116,4 +117,5 @@ jobs:
           files: ./coverage.xml
           flags: unittests  # optional
           name: codecov-umbrella  # optional
+          token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true  # optional (default = false)


### PR DESCRIPTION
@vferat Can you check in the settings that we do have the `CODECOV_TOKEN` correctly set?
It's now a required argunebt with `codecov/codecov-action@v4` 