### PR TITLE
Improve figure size and show argument in viz functions

### DIFF
--- a/pycrostates/_typing.py
+++ b/pycrostates/_typing.py
@@ -11,25 +11,25 @@ from numpy.random import Generator, RandomState
 from numpy.typing import NDArray
 
 
-class CHData(ABC):
+class CHData(ABC):  # noqa: B024
     """Typing for CHData."""
 
     pass
 
 
-class CHInfo(ABC):
+class CHInfo(ABC):  # noqa: B024
     """Typing for CHInfo."""
 
     pass
 
 
-class Cluster(ABC):
+class Cluster(ABC):  # noqa: B024
     """Typing for a clustering class."""
 
     pass
 
 
-class Segmentation(ABC):
+class Segmentation(ABC):  # noqa: B024
     """Typing for a clustering class."""
 
     pass

--- a/pycrostates/cluster/_base.py
+++ b/pycrostates/cluster/_base.py
@@ -518,7 +518,7 @@ class _BaseCluster(Cluster, ChannelsMixin, ContainsMixin, MontageMixin):
         self,
         axes: Optional[Union[Axes, NDArray[Axes]]] = None,
         show_gradient: Optional[bool] = False,
-        gradient_kwargs: dict[str, Any] = {
+        gradient_kwargs: dict[str, Any] = {  # noqa: B006
             "color": "black",
             "linestyle": "-",
             "marker": "P",

--- a/pycrostates/cluster/_base.py
+++ b/pycrostates/cluster/_base.py
@@ -525,6 +525,7 @@ class _BaseCluster(Cluster, ChannelsMixin, ContainsMixin, MontageMixin):
         },
         *,
         block: bool = False,
+        show: Optional[bool] = None,
         verbose: Optional[str] = None,
         **kwargs,
     ):
@@ -541,6 +542,7 @@ class _BaseCluster(Cluster, ChannelsMixin, ContainsMixin, MontageMixin):
             Additional keyword arguments passed to :meth:`matplotlib.axes.Axes.plot` to
             plot gradient line.
         %(block)s
+        %(show)s
         %(verbose)s
         **kwargs
             Additional keyword arguments are passed to :func:`mne.viz.plot_topomap`.
@@ -561,6 +563,7 @@ class _BaseCluster(Cluster, ChannelsMixin, ContainsMixin, MontageMixin):
             show_gradient=show_gradient,
             gradient_kwargs=gradient_kwargs,
             block=block,
+            show=show,
             verbose=verbose,
             **kwargs,
         )

--- a/pycrostates/cluster/_base.pyi
+++ b/pycrostates/cluster/_base.pyi
@@ -199,6 +199,7 @@ class _BaseCluster(Cluster, ChannelsMixin, ContainsMixin, MontageMixin):
         },
         *,
         block: bool = False,
+        show: Optional[bool] = None,
         verbose: Optional[str] = None,
         **kwargs,
     ):
@@ -219,6 +220,9 @@ class _BaseCluster(Cluster, ChannelsMixin, ContainsMixin, MontageMixin):
             plot gradient line.
         block : bool
             Whether to halt program execution until the figure is closed.
+        show : bool | None
+            If True, the figure is shown. If None, the figure is shown if the matplotlib backend
+            is interactive.
         verbose : int | str | bool | None
             Sets the verbosity level. The verbosity increases gradually between ``"CRITICAL"``,
             ``"ERROR"``, ``"WARNING"``, ``"INFO"`` and ``"DEBUG"``. If None is provided, the

--- a/pycrostates/cluster/tests/test_aahc.py
+++ b/pycrostates/cluster/tests/test_aahc.py
@@ -480,15 +480,15 @@ def test_properties(caplog):
         normalize_input=False,
     )
 
-    aahCluster_.cluster_centers_  # pylint: disable=pointless-statement
+    aahCluster_.cluster_centers_  # noqa: B018
     assert "Clustering algorithm has not been fitted." in caplog.text
     caplog.clear()
 
-    aahCluster_.info  # pylint: disable=pointless-statement
+    aahCluster_.info  # noqa: B018
     assert "Clustering algorithm has not been fitted." in caplog.text
     caplog.clear()
 
-    aahCluster_.fitted_data  # pylint: disable=pointless-statement
+    aahCluster_.fitted_data  # noqa: B018
     assert "Clustering algorithm has not been fitted." in caplog.text
     caplog.clear()
 

--- a/pycrostates/cluster/tests/test_kmeans.py
+++ b/pycrostates/cluster/tests/test_kmeans.py
@@ -407,7 +407,7 @@ def test_properties(caplog):
     # Fitted
     ModK_ = ModK.copy()
 
-    ModK_.cluster_centers  # noqa: B018
+    ModK_.cluster_centers_  # noqa: B018
     assert "Clustering algorithm has not been fitted." not in caplog.text
     caplog.clear()
 
@@ -1100,7 +1100,7 @@ def test_contains_mixin():
     with pytest.raises(
         ValueError, match="Instance 'ModKMeans' attribute 'info' is None."
     ):
-        "eeg" in ModK  # noqa: B015
+        "eeg" in ModK_  # noqa: B015
     with pytest.raises(
         ValueError, match="Instance 'ModKMeans' attribute 'info' is None."
     ):

--- a/pycrostates/cluster/tests/test_kmeans.py
+++ b/pycrostates/cluster/tests/test_kmeans.py
@@ -392,30 +392,30 @@ def test_properties(caplog):
         random_state=1,
     )
 
-    ModK_.cluster_centers_  # pylint: disable=pointless-statement
+    ModK_.cluster_centers_  # noqa: B018
     assert "Clustering algorithm has not been fitted." in caplog.text
     caplog.clear()
 
-    ModK_.info  # pylint: disable=pointless-statement
+    ModK_.info  # noqa: B018
     assert "Clustering algorithm has not been fitted." in caplog.text
     caplog.clear()
 
-    ModK_.fitted_data  # pylint: disable=pointless-statement
+    ModK_.fitted_data  # noqa: B018
     assert "Clustering algorithm has not been fitted." in caplog.text
     caplog.clear()
 
     # Fitted
     ModK_ = ModK.copy()
 
-    ModK_.cluster_centers_
+    ModK_.cluster_centers  # noqa: B018
     assert "Clustering algorithm has not been fitted." not in caplog.text
     caplog.clear()
 
-    ModK_.info
+    ModK_.info  # noqa: B018
     assert "Clustering algorithm has not been fitted." not in caplog.text
     caplog.clear()
 
-    ModK_.fitted_data
+    ModK_.fitted_data  # noqa: B018
     assert "Clustering algorithm has not been fitted." not in caplog.text
     caplog.clear()
 
@@ -1100,7 +1100,7 @@ def test_contains_mixin():
     with pytest.raises(
         ValueError, match="Instance 'ModKMeans' attribute 'info' is None."
     ):
-        "eeg" in ModK_
+        "eeg" in ModK  # noqa: B015
     with pytest.raises(
         ValueError, match="Instance 'ModKMeans' attribute 'info' is None."
     ):
@@ -1108,7 +1108,7 @@ def test_contains_mixin():
     with pytest.raises(
         ValueError, match="Instance 'ModKMeans' attribute 'info' is None."
     ):
-        ModK_.compensation_grade
+        ModK_.compensation_grade  # noqa: B018
 
 
 def test_montage_mixin():

--- a/pycrostates/io/tests/test_meas_info.py
+++ b/pycrostates/io/tests/test_meas_info.py
@@ -60,7 +60,7 @@ def test_create_from_info():
     info.set_montage("standard_1020")
     chinfo = ChInfo(info=info)
     assert chinfo["ch_names"] == ["Fp1", "Fp2", "Fpz"]
-    for k, ch in enumerate(info["chs"]):
+    for ch in info["chs"]:
         assert ch["coord_frame"] == FIFF.FIFFV_COORD_HEAD
         assert not all(np.isnan(elt) for elt in ch["loc"])
     assert chinfo["dig"] is not None
@@ -228,7 +228,7 @@ def test_montage():
     info.set_montage("standard_1020")
     chinfo = ChInfo(info=info)
     assert chinfo["ch_names"] == ["Fp1", "Fp2", "Fpz"]
-    for k, ch in enumerate(info["chs"]):
+    for ch in info["chs"]:
         assert ch["coord_frame"] == FIFF.FIFFV_COORD_HEAD
         assert not all(np.isnan(elt) for elt in ch["loc"])
     assert chinfo["dig"] is not None
@@ -261,7 +261,7 @@ def test_montage():
         elif isinstance(montage.get_positions()[key], np.ndarray):
             assert_allclose(montage.get_positions()[key], montage2.get_positions()[key])
         elif isinstance(montage.get_positions()[key], OrderedDict):
-            for k, v in montage.get_positions()[key].items():
+            for k in montage.get_positions()[key]:
                 assert_allclose(
                     montage.get_positions()[key][k],
                     montage2.get_positions()[key][k],

--- a/pycrostates/segmentation/_base.py
+++ b/pycrostates/segmentation/_base.py
@@ -304,7 +304,9 @@ class _BaseSegmentation(Segmentation):
     def plot_cluster_centers(
         self,
         axes: Optional[Union[Axes, NDArray[Axes]]] = None,
+        *,
         block: bool = False,
+        show: Optional[bool] = None,
     ):
         """Plot cluster centers as topographic maps.
 
@@ -312,6 +314,7 @@ class _BaseSegmentation(Segmentation):
         ----------
         %(axes_topo)s
         %(block)s
+        %(show)s
 
         Returns
         -------
@@ -324,6 +327,7 @@ class _BaseSegmentation(Segmentation):
             self._cluster_names,
             axes,
             block=block,
+            show=show,
         )
 
     # --------------------------------------------------------------------

--- a/pycrostates/segmentation/_base.pyi
+++ b/pycrostates/segmentation/_base.pyi
@@ -195,7 +195,11 @@ class _BaseSegmentation(Segmentation):
         """
 
     def plot_cluster_centers(
-        self, axes: Optional[Union[Axes, NDArray[Axes]]] = None, block: bool = False
+        self,
+        axes: Optional[Union[Axes, NDArray[Axes]]] = None,
+        *,
+        block: bool = False,
+        show: Optional[bool] = None,
     ):
         """Plot cluster centers as topographic maps.
 
@@ -207,6 +211,9 @@ class _BaseSegmentation(Segmentation):
             ``≥ 1``, an array of axes of size ``n_clusters`` should be provided.
         block : bool
             Whether to halt program execution until the figure is closed.
+        show : bool | None
+            If True, the figure is shown. If None, the figure is shown if the matplotlib backend
+            is interactive.
 
         Returns
         -------

--- a/pycrostates/segmentation/segmentation.py
+++ b/pycrostates/segmentation/segmentation.py
@@ -53,6 +53,7 @@ class RawSegmentation(_BaseSegmentation):
         cbar_axes: Optional[Axes] = None,
         *,
         block: bool = False,
+        show: Optional[bool] = None,
         verbose: Optional[str] = None,
     ):
         """Plot the segmentation.
@@ -65,6 +66,7 @@ class RawSegmentation(_BaseSegmentation):
         %(axes_seg)s
         %(axes_cbar)s
         %(block)s
+        %(show)s
         %(verbose)s
 
         Returns
@@ -84,6 +86,7 @@ class RawSegmentation(_BaseSegmentation):
             axes=axes,
             cbar_axes=cbar_axes,
             block=block,
+            show=show,
             verbose=verbose,
         )
 
@@ -138,6 +141,7 @@ class EpochsSegmentation(_BaseSegmentation):
         cbar_axes: Optional[Axes] = None,
         *,
         block: bool = False,
+        show: Optional[bool] = None,
         verbose=None,
     ):
         """Plot segmentation.
@@ -148,6 +152,7 @@ class EpochsSegmentation(_BaseSegmentation):
         %(axes_seg)s
         %(axes_cbar)s
         %(block)s
+        %(show)s
         %(verbose)s
 
         Returns
@@ -165,6 +170,7 @@ class EpochsSegmentation(_BaseSegmentation):
             axes=axes,
             cbar_axes=cbar_axes,
             block=block,
+            show=show,
             verbose=verbose,
         )
 

--- a/pycrostates/segmentation/segmentation.pyi
+++ b/pycrostates/segmentation/segmentation.pyi
@@ -39,6 +39,7 @@ class RawSegmentation(_BaseSegmentation):
         cbar_axes: Optional[Axes] = None,
         *,
         block: bool = False,
+        show: Optional[bool] = None,
         verbose: Optional[str] = None,
     ):
         """Plot the segmentation.
@@ -59,6 +60,9 @@ class RawSegmentation(_BaseSegmentation):
             axes.
         block : bool
             Whether to halt program execution until the figure is closed.
+        show : bool | None
+            If True, the figure is shown. If None, the figure is shown if the matplotlib backend
+            is interactive.
         verbose : int | str | bool | None
             Sets the verbosity level. The verbosity increases gradually between ``"CRITICAL"``,
             ``"ERROR"``, ``"WARNING"``, ``"INFO"`` and ``"DEBUG"``. If None is provided, the
@@ -100,6 +104,7 @@ class EpochsSegmentation(_BaseSegmentation):
         cbar_axes: Optional[Axes] = None,
         *,
         block: bool = False,
+        show: Optional[bool] = None,
         verbose: Incomplete | None = None,
     ):
         """Plot segmentation.
@@ -116,6 +121,9 @@ class EpochsSegmentation(_BaseSegmentation):
             axes.
         block : bool
             Whether to halt program execution until the figure is closed.
+        show : bool | None
+            If True, the figure is shown. If None, the figure is shown if the matplotlib backend
+            is interactive.
         verbose : int | str | bool | None
             Sets the verbosity level. The verbosity increases gradually between ``"CRITICAL"``,
             ``"ERROR"``, ``"WARNING"``, ``"INFO"`` and ``"DEBUG"``. If None is provided, the

--- a/pycrostates/utils/_checks.py
+++ b/pycrostates/utils/_checks.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
+from matplotlib import pyplot as plt
 from matplotlib.axes import Axes
 from mne import pick_info
 from mne.utils import check_random_state
@@ -337,3 +338,10 @@ def _check_verbose(verbose: Any) -> int:
             )
 
     return verbose
+
+
+def _ensure_valid_show(show: Any) -> bool:
+    """Check show parameter."""
+    _check_type(show, (bool, None), "show")
+    show = plt.isinteractive() if show is None else show
+    return show

--- a/pycrostates/utils/_docs.py
+++ b/pycrostates/utils/_docs.py
@@ -143,6 +143,11 @@ docdict["segmentation"] = """
 segmentation : RawSegmentation | EpochsSegmentation
     Segmentation object containing the microstate symbolic sequence."""
 
+docdict["show"] = """
+show : bool | None
+    If True, the figure is shown. If None, the figure is shown if the matplotlib backend
+    is interactive."""
+
 docdict["stat_expected_transitions"] = """
 stat : str
     Aggregate statistic to compute transitions. Can be:

--- a/pycrostates/utils/_imports.py
+++ b/pycrostates/utils/_imports.py
@@ -1,20 +1,37 @@
-"""
-Optional dependency import.
+"""Handle optional dependency imports.
 
-Inspired from pandas: https://pandas.pydata.org/.
+Inspired from pandas: https://pandas.pydata.org/
 """
+
+from __future__ import annotations  # c.f. PEP 563, PEP 649
+
 import importlib
+from typing import TYPE_CHECKING
+from warnings import warn
 
-from ._logs import logger
+if TYPE_CHECKING:
+    from types import ModuleType
+    from typing import Optional
 
 # A mapping from import name to package name (on PyPI) when the package name
-# is different. {python: PyPI}
-_INSTALL_MAPPING: dict[str, str] = {}
+# is different.
+_INSTALL_MAPPING: dict[str, str] = {
+    "codespell_lib": "codespell",
+    "cv2": "opencv-python",
+    "parallel": "pyparallel",
+    "pytest_cov": "pytest-cov",
+    "serial": "pyserial",
+    "sklearn": "scikit-learn",
+    "sksparse": "scikit-sparse",
+}
 
 
-def import_optional_dependency(name: str, extra: str = "", raise_error: bool = True):
-    """
-    Import an optional dependency.
+def import_optional_dependency(
+    name: str,
+    extra: str = "",
+    raise_error: bool = True,
+) -> Optional[ModuleType]:
+    """Import an optional dependency.
 
     By default, if a dependency is missing an ImportError with a nice message will be
     raised.
@@ -27,14 +44,12 @@ def import_optional_dependency(name: str, extra: str = "", raise_error: bool = T
         Additional text to include in the ImportError message.
     raise_error : bool
         What to do when a dependency is not found.
-        * True : If the module is not installed, raise an ImportError, otherwise, return
-                 the module.
-        * False: If the module is not installed, issue a warning and return None,
-                 otherwise, return the module.
+        * True : Raise an ImportError.
+        * False: Return None.
 
     Returns
     -------
-    maybe_module : Optional[ModuleType]
+    module : Module | None
         The imported module when found.
         None is returned when the package is not found and raise_error is False.
     """
@@ -45,12 +60,13 @@ def import_optional_dependency(name: str, extra: str = "", raise_error: bool = T
         module = importlib.import_module(name)
     except ImportError:
         msg = (
-            f"Missing optional dependency '{install_name}'. {extra} "
-            f"Use pip or conda to install '{install_name}'."
+            f"Missing optional dependency '{install_name}'. {extra} Use pip or "
+            f"conda to install {install_name}."
         )
         if raise_error:
             raise ImportError(msg)
-        logger.warning(msg)
-        return None
+        else:
+            warn(msg, RuntimeWarning, stacklevel=2)
+            return None
 
     return module

--- a/pycrostates/utils/_imports.pyi
+++ b/pycrostates/utils/_imports.pyi
@@ -1,10 +1,12 @@
-from ._logs import logger as logger
+from types import ModuleType as ModuleType
+from typing import Optional
 
 _INSTALL_MAPPING: dict[str, str]
 
-def import_optional_dependency(name: str, extra: str = "", raise_error: bool = True):
-    """
-    Import an optional dependency.
+def import_optional_dependency(
+    name: str, extra: str = "", raise_error: bool = True
+) -> Optional[ModuleType]:
+    """Import an optional dependency.
 
     By default, if a dependency is missing an ImportError with a nice message will be
     raised.
@@ -17,14 +19,12 @@ def import_optional_dependency(name: str, extra: str = "", raise_error: bool = T
         Additional text to include in the ImportError message.
     raise_error : bool
         What to do when a dependency is not found.
-        * True : If the module is not installed, raise an ImportError, otherwise, return
-                 the module.
-        * False: If the module is not installed, issue a warning and return None,
-                 otherwise, return the module.
+        * True : Raise an ImportError.
+        * False: Return None.
 
     Returns
     -------
-    maybe_module : Optional[ModuleType]
+    module : Module | None
         The imported module when found.
         None is returned when the package is not found and raise_error is False.
     """

--- a/pycrostates/utils/tests/test_imports.py
+++ b/pycrostates/utils/tests/test_imports.py
@@ -2,30 +2,23 @@
 
 import pytest
 
-from pycrostates.utils._imports import import_optional_dependency
-from pycrostates.utils._logs import logger, set_log_level
-
-set_log_level("INFO")
-logger.propagate = True
+from .._imports import import_optional_dependency
 
 
-def test_import_optional_dependency(caplog):
+def test_import_optional_dependency():
     """Test the import of optional dependencies."""
     # Test import of present package
     numpy = import_optional_dependency("numpy")
     assert isinstance(numpy.__version__, str)
 
     # Test import of absent package
-    caplog.clear()
     with pytest.raises(ImportError, match="Missing optional dependency"):
         import_optional_dependency("non_existing_pkg", raise_error=True)
-    assert "Missing optional dependency" not in caplog.text
 
     # Test import of absent package without raise
-    caplog.clear()
-    pkg = import_optional_dependency("non_existing_pkg", raise_error=False)
+    with pytest.warns(RuntimeWarning, match="Missing optional dependency"):
+        pkg = import_optional_dependency("non_existing_pkg", raise_error=False)
     assert pkg is None
-    assert "Missing optional dependency" in caplog.text
 
     # Test extra
     with pytest.raises(ImportError, match="blabla"):

--- a/pycrostates/utils/tests/test_mixin.py
+++ b/pycrostates/utils/tests/test_mixin.py
@@ -39,18 +39,18 @@ def test_contains_mixin():
     # test with info equal to None
     foo = Foo(None)
     with pytest.raises(ValueError, match="Instance 'Foo' attribute 'info' is None."):
-        "eeg" in foo
+        "eeg" in foo  # noqa: B015
     with pytest.raises(ValueError, match="Instance 'Foo' attribute 'info' is None."):
         foo.get_channel_types()
     with pytest.raises(ValueError, match="Instance 'Foo' attribute 'info' is None."):
-        foo.compensation_grade
+        foo.compensation_grade  # noqa: B018
 
     # test without attribute info
     foo = Foo2()
     with pytest.raises(
         ValueError, match="Instance 'Foo2' is missing an attribute 'info'"
     ):
-        "eeg" in foo
+        "eeg" in foo  # noqa: B015
     with pytest.raises(
         ValueError, match="Instance 'Foo2' is missing an attribute 'info'"
     ):
@@ -58,7 +58,7 @@ def test_contains_mixin():
     with pytest.raises(
         ValueError, match="Instance 'Foo2' is missing an attribute 'info'"
     ):
-        foo.compensation_grade
+        foo.compensation_grade  # noqa: B018
 
 
 def test_montage_mixin():

--- a/pycrostates/viz/cluster_centers.py
+++ b/pycrostates/viz/cluster_centers.py
@@ -33,6 +33,7 @@ def plot_cluster_centers(
     gradient_kwargs: dict[str, Any] = _GRADIENT_KWARGS_DEFAULTS,
     *,
     block: bool = False,
+    show: Optional[bool] = None,
     verbose: Optional[str] = None,
     **kwargs,
 ):
@@ -51,6 +52,7 @@ def plot_cluster_centers(
         Additional keyword arguments passed to :meth:`matplotlib.axes.Axes.plot` to plot
         gradient line.
     %(block)s
+    %(show)s
     %(verbose)s
     **kwargs
         Additional keyword arguments are passed to :func:`mne.viz.plot_topomap`.
@@ -79,6 +81,8 @@ def plot_cluster_centers(
             "'show_gradient' is set to False."
         )
     _check_type(block, (bool,), "block")
+    _check_type(show, (bool, None), "show")
+    show = plt.isinteractive() if show is None else show
 
     # check cluster_names
     if cluster_names is None:
@@ -122,14 +126,6 @@ def plot_cluster_centers(
         else:
             f = figs
         del figs
-
-    # remove show from kwargs passed to topoplot
-    if "show" in kwargs:
-        show = kwargs["show"]
-        _check_type(show, (bool,), "show")
-        del kwargs["show"]
-    else:
-        show = plt.isinteractive()
 
     # plot cluster centers
     for k, (center, name) in enumerate(zip(cluster_centers, cluster_names)):

--- a/pycrostates/viz/cluster_centers.py
+++ b/pycrostates/viz/cluster_centers.py
@@ -92,7 +92,9 @@ def plot_cluster_centers(
     # create axes if needed, and retrieve figure
     n_clusters = cluster_centers.shape[0]
     if axes is None:
-        f, axes = plt.subplots(1, n_clusters, layout="constrained")
+        f, axes = plt.subplots(
+            1, n_clusters, figsize=(3 * n_clusters, 3), layout="constrained"
+        )
         if isinstance(axes, Axes):
             axes = np.array([axes])  # wrap in an array-like
         # sanity-check

--- a/pycrostates/viz/cluster_centers.py
+++ b/pycrostates/viz/cluster_centers.py
@@ -11,7 +11,7 @@ from mne.viz import plot_topomap
 from numpy.typing import NDArray
 
 from .._typing import CHInfo
-from ..utils._checks import _check_axes, _check_type
+from ..utils._checks import _check_axes, _check_type, _ensure_valid_show
 from ..utils._docs import fill_doc
 from ..utils._logs import logger, verbose
 
@@ -81,8 +81,7 @@ def plot_cluster_centers(
             "'show_gradient' is set to False."
         )
     _check_type(block, (bool,), "block")
-    _check_type(show, (bool, None), "show")
-    show = plt.isinteractive() if show is None else show
+    show = _ensure_valid_show(show)
 
     # check cluster_names
     if cluster_names is None:

--- a/pycrostates/viz/cluster_centers.pyi
+++ b/pycrostates/viz/cluster_centers.pyi
@@ -21,6 +21,7 @@ def plot_cluster_centers(
     gradient_kwargs: dict[str, Any] = ...,
     *,
     block: bool = False,
+    show: Optional[bool] = None,
     verbose: Optional[str] = None,
     **kwargs,
 ):
@@ -45,6 +46,9 @@ def plot_cluster_centers(
         gradient line.
     block : bool
         Whether to halt program execution until the figure is closed.
+    show : bool | None
+        If True, the figure is shown. If None, the figure is shown if the matplotlib backend
+        is interactive.
     verbose : int | str | bool | None
         Sets the verbosity level. The verbosity increases gradually between ``"CRITICAL"``,
         ``"ERROR"``, ``"WARNING"``, ``"INFO"`` and ``"DEBUG"``. If None is provided, the

--- a/pycrostates/viz/segmentation.py
+++ b/pycrostates/viz/segmentation.py
@@ -29,6 +29,7 @@ def plot_raw_segmentation(
     cbar_axes: Optional[Axes] = None,
     *,
     block: bool = False,
+    show: Optional[bool] = None,
     verbose: Optional[str] = None,
     **kwargs,
 ):
@@ -47,6 +48,7 @@ def plot_raw_segmentation(
     %(axes_seg)s
     %(axes_cbar)s
     %(block)s
+    %(show)s
     %(verbose)s
     **kwargs
         Kwargs are passed to ``axes.plot``.
@@ -61,6 +63,8 @@ def plot_raw_segmentation(
         raise ValueError("Argument 'labels' should be a 1D array.")
     _check_type(raw, (BaseRaw,), "raw")
     _check_type(block, (bool,), "block")
+    _check_type(show, (bool, None), "show")
+    show = plt.isinteractive() if show is None else show
 
     data = raw.get_data(tmin=tmin, tmax=tmax)
     gfp = np.std(data, axis=0)
@@ -81,7 +85,7 @@ def plot_raw_segmentation(
             "Argument 'labels' and 'raw' do not have the same number of samples."
         )
 
-    fig, axes, show = _plot_segmentation(
+    fig, axes = _plot_segmentation(
         labels,
         gfp,
         times,
@@ -113,6 +117,7 @@ def plot_epoch_segmentation(
     cbar_axes: Optional[Axes] = None,
     *,
     block: bool = False,
+    show: Optional[bool] = None,
     verbose: Optional[str] = None,
     **kwargs,
 ):
@@ -130,6 +135,7 @@ def plot_epoch_segmentation(
     %(axes_seg)s
     %(axes_cbar)s
     %(block)s
+    %(show)s
     %(verbose)s
     **kwargs
         Kwargs are passed to ``axes.plot``.
@@ -144,6 +150,8 @@ def plot_epoch_segmentation(
         raise ValueError("Argument labels should be a 2D array.")
     _check_type(epochs, (BaseEpochs,), "epochs")
     _check_type(block, (bool,), "block")
+    _check_type(show, (bool, None), "show")
+    show = plt.isinteractive() if show is None else show
 
     kwargs_epochs = dict(copy=False) if check_version("mne", "1.6") else dict()
     data = epochs.get_data(**kwargs_epochs).swapaxes(0, 1)
@@ -158,7 +166,7 @@ def plot_epoch_segmentation(
             "Argument 'labels' and 'epochs' do not have the same number of samples."
         )
 
-    fig, axes, show = _plot_segmentation(
+    fig, axes = _plot_segmentation(
         labels,
         gfp,
         times,
@@ -207,7 +215,7 @@ def _plot_segmentation(
     *,
     verbose: Optional[str] = None,
     **kwargs,
-):
+) -> tuple[plt.Figure, Axes]:
     """Code snippet to plot segmentation for raw and epochs."""
     _check_type(labels, (np.ndarray,), "labels")  # 1D array (n_times, )
     _check_type(gfp, (np.ndarray,), "gfp")  # 1D array (n_times, )
@@ -236,14 +244,6 @@ def _plot_segmentation(
         fig, axes = plt.subplots(1, 1, layout="constrained")
     else:
         fig = axes.get_figure()
-
-    # remove show from kwargs passed to plot
-    if "show" in kwargs:
-        show = kwargs["show"]
-        _check_type(show, (bool,), "show")
-        del kwargs["show"]
-    else:
-        show = plt.isinteractive()
 
     # add color and linewidth if absent from kwargs
     if "color" not in kwargs:
@@ -288,7 +288,7 @@ def _plot_segmentation(
     )
     colorbar.ax.set_yticklabels(cluster_names)
 
-    return fig, axes, show
+    return fig, axes
 
 
 def _compatibility_cmap(

--- a/pycrostates/viz/segmentation.py
+++ b/pycrostates/viz/segmentation.py
@@ -11,7 +11,7 @@ from mne.io import BaseRaw
 from mne.utils import check_version
 from numpy.typing import NDArray
 
-from ..utils._checks import _check_type
+from ..utils._checks import _check_type, _ensure_valid_show
 from ..utils._docs import fill_doc
 from ..utils._logs import logger, verbose
 
@@ -63,8 +63,7 @@ def plot_raw_segmentation(
         raise ValueError("Argument 'labels' should be a 1D array.")
     _check_type(raw, (BaseRaw,), "raw")
     _check_type(block, (bool,), "block")
-    _check_type(show, (bool, None), "show")
-    show = plt.isinteractive() if show is None else show
+    show = _ensure_valid_show(show)
 
     data = raw.get_data(tmin=tmin, tmax=tmax)
     gfp = np.std(data, axis=0)
@@ -150,8 +149,7 @@ def plot_epoch_segmentation(
         raise ValueError("Argument labels should be a 2D array.")
     _check_type(epochs, (BaseEpochs,), "epochs")
     _check_type(block, (bool,), "block")
-    _check_type(show, (bool, None), "show")
-    show = plt.isinteractive() if show is None else show
+    show = _ensure_valid_show(show)
 
     kwargs_epochs = dict(copy=False) if check_version("mne", "1.6") else dict()
     data = epochs.get_data(**kwargs_epochs).swapaxes(0, 1)

--- a/pycrostates/viz/segmentation.pyi
+++ b/pycrostates/viz/segmentation.pyi
@@ -1,6 +1,7 @@
 from typing import Optional, Union
 
 from matplotlib import colors
+from matplotlib import pyplot as plt
 from matplotlib.axes import Axes
 from mne import BaseEpochs
 from mne.io import BaseRaw
@@ -22,6 +23,7 @@ def plot_raw_segmentation(
     cbar_axes: Optional[Axes] = None,
     *,
     block: bool = False,
+    show: Optional[bool] = None,
     verbose: Optional[str] = None,
     **kwargs,
 ):
@@ -51,6 +53,9 @@ def plot_raw_segmentation(
         axes.
     block : bool
         Whether to halt program execution until the figure is closed.
+    show : bool | None
+        If True, the figure is shown. If None, the figure is shown if the matplotlib backend
+        is interactive.
     verbose : int | str | bool | None
         Sets the verbosity level. The verbosity increases gradually between ``"CRITICAL"``,
         ``"ERROR"``, ``"WARNING"``, ``"INFO"`` and ``"DEBUG"``. If None is provided, the
@@ -75,6 +80,7 @@ def plot_epoch_segmentation(
     cbar_axes: Optional[Axes] = None,
     *,
     block: bool = False,
+    show: Optional[bool] = None,
     verbose: Optional[str] = None,
     **kwargs,
 ):
@@ -101,6 +107,9 @@ def plot_epoch_segmentation(
         axes.
     block : bool
         Whether to halt program execution until the figure is closed.
+    show : bool | None
+        If True, the figure is shown. If None, the figure is shown if the matplotlib backend
+        is interactive.
     verbose : int | str | bool | None
         Sets the verbosity level. The verbosity increases gradually between ``"CRITICAL"``,
         ``"ERROR"``, ``"WARNING"``, ``"INFO"`` and ``"DEBUG"``. If None is provided, the
@@ -127,7 +136,7 @@ def _plot_segmentation(
     *,
     verbose: Optional[str] = None,
     **kwargs,
-):
+) -> tuple[plt.Figure, Axes]:
     """Code snippet to plot segmentation for raw and epochs."""
 
 def _compatibility_cmap(cmap: Optional[Union[str, colors.Colormap]], n_colors: int):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,13 +167,16 @@ docstring-code-format = true
 
 [tool.ruff.lint]
 ignore = []
-select = ['E', 'F', 'UP', 'W']
+select = ['A', 'B', 'E', 'F', 'UP', 'W']
 
 [tool.ruff.lint.per-file-ignores]
 '*' = [
-  "UP007", # 'Use `X | Y` for type annotations', requires python 3.10
+  'B904', # 'Within an except clause, raise exceptions with raise ... from ...'
+  'UP007', # 'Use `X | Y` for type annotations', requires python 3.10
 ]
-'*.pyi' = ['E501', 'F811']
+'*.pyi' = ['E501']
+'*/cluster/_base.pyi' = ['B006']
+'*/segmentation/_base.pyi' = ['F811']
 '__init__.py' = ['F401']
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,19 +159,21 @@ extend-exclude = [
   'doc',
   'setup.py',
 ]
-ignore = []
 line-length = 88
-select = ["E", "F", "UP", "W"]
 target-version = 'py39'
 
 [tool.ruff.format]
 docstring-code-format = true
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint]
+ignore = []
+select = ['E', 'F', 'UP', 'W']
+
+[tool.ruff.lint.per-file-ignores]
 '*' = [
   "UP007", # 'Use `X | Y` for type annotations', requires python 3.10
 ]
-'*.pyi' = ['E501']
+'*.pyi' = ['E501', 'F811']
 '__init__.py' = ['F401']
 
 [tool.setuptools]


### PR DESCRIPTION
Closes #97 
Closes #126 

Try to define a better figsize for cluster center plots.
Move the show argument outsides of the kwargs of the viz functions to make it explicit.
Fix ruff configuration which now requires separate `tools.ruff.lint` and `tools.ruff.format` section.
Enable ruff lint rules `A` and `B`.