### PR TITLE
Fix typing-related warnings

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -247,10 +247,7 @@ sphinx_gallery_conf = {
     "compress_images": compress_images,
     "doc_module": ("pycrostates",),
     "examples_dirs": ["../../tutorials"],
-    "exclude_implicit_doc": {
-        r"pycrostates.CHData",
-        r"pycrostates.ChData.get_data",
-    },
+    "exclude_implicit_doc": {},
     "filename_pattern": r"\d{2}_",
     "gallery_dirs": ["generated/auto_tutorials"],
     "line_numbers": False,  # messes with style

--- a/pycrostates/_typing.py
+++ b/pycrostates/_typing.py
@@ -1,6 +1,5 @@
 from __future__ import annotations  # c.f. PEP 563, PEP 649
 
-from abc import ABC
 from typing import Generic, Optional, TypeVar, Union
 
 import numpy as np
@@ -27,12 +26,6 @@ class ScalarArray(np.ndarray, Generic[ScalarType]):
 
 
 class AxesArray(np.ndarray, Generic[TypeVar("AxesType", bound=Axes)]):
-    pass
-
-
-class Segmentation(ABC):  # noqa: B024
-    """Typing for a clustering class."""
-
     pass
 
 

--- a/pycrostates/_typing.py
+++ b/pycrostates/_typing.py
@@ -30,12 +30,6 @@ class AxesArray(np.ndarray, Generic[TypeVar("AxesType", Axes)]):
     pass
 
 
-class CHData(ABC):  # noqa: B024
-    """Typing for CHData."""
-
-    pass
-
-
 class CHInfo(ABC):  # noqa: B024
     """Typing for CHInfo."""
 

--- a/pycrostates/_typing.py
+++ b/pycrostates/_typing.py
@@ -1,14 +1,33 @@
-"""Typing with ABC class for pycrostates classes.
-
-The type class can be used for type hinting for pycrostates classes that are at
-risk of circular imports, or for short-cut types re-grouping different types.
-"""
+from __future__ import annotations  # c.f. PEP 563, PEP 649
 
 from abc import ABC
-from typing import Optional, Union
+from typing import Generic, Optional, TypeVar, Union
 
+import numpy as np
+from matplotlib.axes import Axes
 from numpy.random import Generator, RandomState
-from numpy.typing import NDArray
+
+ScalarFloatType = TypeVar("ScalarFloatType", np.float32, np.float64)
+ScalarIntType = TypeVar("ScalarIntType", np.int8, np.int16, np.int32, np.int64)
+ScalarType = TypeVar(
+    "ScalarType", np.int8, np.int16, np.int32, np.int64, np.float32, np.float64
+)
+
+
+class ScalarFloatArray(np.ndarray, Generic[ScalarFloatType]):
+    pass
+
+
+class ScalarIntArray(np.ndarray, Generic[ScalarIntType]):
+    pass
+
+
+class ScalarArray(np.ndarray, Generic[ScalarType]):
+    pass
+
+
+class AxesArray(np.ndarray, Generic[TypeVar("AxesType", Axes)]):
+    pass
 
 
 class CHData(ABC):  # noqa: B024
@@ -36,4 +55,4 @@ class Segmentation(ABC):  # noqa: B024
 
 
 RANDomState = Optional[Union[int, RandomState, Generator]]
-Picks = Optional[Union[str, NDArray[int]]]
+Picks = Optional[Union[str, ScalarIntArray]]

--- a/pycrostates/_typing.py
+++ b/pycrostates/_typing.py
@@ -1,10 +1,11 @@
 from __future__ import annotations  # c.f. PEP 563, PEP 649
 
-from typing import Generic, Optional, TypeVar, Union
+from typing import Generic, TypeVar
 
 import numpy as np
 from matplotlib.axes import Axes
-from numpy.random import Generator, RandomState
+from numpy.random import Generator
+from numpy.random import RandomState as RandomState_np
 
 ScalarFloatType = TypeVar("ScalarFloatType", np.float32, np.float64)
 ScalarIntType = TypeVar("ScalarIntType", np.int8, np.int16, np.int32, np.int64)
@@ -29,5 +30,7 @@ class AxesArray(np.ndarray, Generic[TypeVar("AxesType", bound=Axes)]):
     pass
 
 
-RANDomState = Optional[Union[int, RandomState, Generator]]
-Picks = Optional[Union[str, ScalarIntArray]]
+RandomState = TypeVar("RandomState", int, RandomState_np, Generator)
+Picks = TypeVar(
+    "Picks", str, ScalarIntArray, list[str], list[int], tuple[str], tuple[int], None
+)

--- a/pycrostates/_typing.py
+++ b/pycrostates/_typing.py
@@ -26,13 +26,7 @@ class ScalarArray(np.ndarray, Generic[ScalarType]):
     pass
 
 
-class AxesArray(np.ndarray, Generic[TypeVar("AxesType", Axes)]):
-    pass
-
-
-class CHInfo(ABC):  # noqa: B024
-    """Typing for CHInfo."""
-
+class AxesArray(np.ndarray, Generic[TypeVar("AxesType", bound=Axes)]):
     pass
 
 

--- a/pycrostates/_typing.py
+++ b/pycrostates/_typing.py
@@ -30,12 +30,6 @@ class AxesArray(np.ndarray, Generic[TypeVar("AxesType", bound=Axes)]):
     pass
 
 
-class Cluster(ABC):  # noqa: B024
-    """Typing for a clustering class."""
-
-    pass
-
-
 class Segmentation(ABC):  # noqa: B024
     """Typing for a clustering class."""
 

--- a/pycrostates/cluster/_base.py
+++ b/pycrostates/cluster/_base.py
@@ -1,16 +1,16 @@
+from __future__ import annotations  # c.f. PEP 563, PEP 649
+
 from abc import abstractmethod
 from copy import copy, deepcopy
 from itertools import groupby
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import TYPE_CHECKING
 
 import numpy as np
-from matplotlib.axes import Axes
 from mne import BaseEpochs, pick_info
 from mne.annotations import _annotations_starts_stops
 from mne.io import BaseRaw
 from mne.utils import check_version
-from numpy.typing import NDArray
 from scipy.signal import convolve2d
 
 if check_version("mne", "1.6"):
@@ -18,14 +18,6 @@ if check_version("mne", "1.6"):
 else:
     from mne.io.pick import _picks_to_idx
 
-from .._typing import (
-    AxesArray,
-    CHData,
-    Cluster,
-    Picks,
-    ScalarFloatArray,
-    ScalarIntArray,
-)
 from ..segmentation import EpochsSegmentation, RawSegmentation
 from ..utils import _corr_vectors
 from ..utils._checks import (
@@ -40,6 +32,15 @@ from ..utils._logs import logger, verbose
 from ..utils.mixin import ChannelsMixin, ContainsMixin, MontageMixin
 from ..viz import plot_cluster_centers
 from .utils import optimize_order
+
+if TYPE_CHECKING:
+    from typing import Any, Optional, Union
+
+    from matplotlib.axes import Axes
+    from numpy.typing import NDArray
+
+    from .._typing import AxesArray, Cluster, Picks, ScalarFloatArray, ScalarIntArray
+    from ..io import ChData
 
 
 class _BaseCluster(Cluster, ChannelsMixin, ContainsMixin, MontageMixin):
@@ -199,7 +200,7 @@ class _BaseCluster(Cluster, ChannelsMixin, ContainsMixin, MontageMixin):
     @verbose
     def fit(
         self,
-        inst: Union[BaseRaw, BaseEpochs, CHData],
+        inst: Union[BaseRaw, BaseEpochs, ChData],
         picks: Picks = "eeg",
         tmin: Optional[Union[int, float]] = None,
         tmax: Optional[Union[int, float]] = None,

--- a/pycrostates/cluster/_base.py
+++ b/pycrostates/cluster/_base.py
@@ -39,11 +39,11 @@ if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from numpy.typing import NDArray
 
-    from .._typing import AxesArray, Cluster, Picks, ScalarFloatArray, ScalarIntArray
+    from .._typing import AxesArray, Picks, ScalarFloatArray, ScalarIntArray
     from ..io import ChData
 
 
-class _BaseCluster(Cluster, ChannelsMixin, ContainsMixin, MontageMixin):
+class _BaseCluster(ChannelsMixin, ContainsMixin, MontageMixin):
     """Base Class for Microstates Clustering algorithms."""
 
     @abstractmethod
@@ -357,7 +357,7 @@ class _BaseCluster(Cluster, ChannelsMixin, ContainsMixin, MontageMixin):
                 ScalarIntArray,
             ]
         ] = None,
-        template: Optional[Cluster] = None,
+        template: Optional[_BaseCluster] = None,
     ) -> None:
         """
         Reorder the clusters of the fitted model.

--- a/pycrostates/cluster/_base.py
+++ b/pycrostates/cluster/_base.py
@@ -1,6 +1,6 @@
 from __future__ import annotations  # c.f. PEP 563, PEP 649
 
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from copy import copy, deepcopy
 from itertools import groupby
 from pathlib import Path
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
     from ..io import ChData
 
 
-class _BaseCluster(ChannelsMixin, ContainsMixin, MontageMixin):
+class _BaseCluster(ABC, ChannelsMixin, ContainsMixin, MontageMixin):
     """Base Class for Microstates Clustering algorithms."""
 
     @abstractmethod

--- a/pycrostates/cluster/_base.py
+++ b/pycrostates/cluster/_base.py
@@ -18,7 +18,14 @@ if check_version("mne", "1.6"):
 else:
     from mne.io.pick import _picks_to_idx
 
-from .._typing import CHData, Cluster, Picks
+from .._typing import (
+    AxesArray,
+    CHData,
+    Cluster,
+    Picks,
+    ScalarFloatArray,
+    ScalarIntArray,
+)
 from ..segmentation import EpochsSegmentation, RawSegmentation
 from ..utils import _corr_vectors
 from ..utils._checks import (
@@ -199,7 +206,7 @@ class _BaseCluster(Cluster, ChannelsMixin, ContainsMixin, MontageMixin):
         reject_by_annotation: bool = True,
         *,
         verbose: Optional[str] = None,
-    ) -> NDArray[float]:
+    ) -> ScalarFloatArray:
         """Compute cluster centers.
 
         Parameters
@@ -346,7 +353,7 @@ class _BaseCluster(Cluster, ChannelsMixin, ContainsMixin, MontageMixin):
             Union[
                 list[int],
                 tuple[int, ...],
-                NDArray[int],
+                ScalarIntArray,
             ]
         ] = None,
         template: Optional[Cluster] = None,
@@ -460,7 +467,7 @@ class _BaseCluster(Cluster, ChannelsMixin, ContainsMixin, MontageMixin):
             bool,
             list[bool],
             tuple[bool, ...],
-            NDArray[bool],
+            NDArray[np.bool],
         ],
     ) -> None:
         """Invert map polarities.
@@ -516,7 +523,7 @@ class _BaseCluster(Cluster, ChannelsMixin, ContainsMixin, MontageMixin):
     @verbose
     def plot(
         self,
-        axes: Optional[Union[Axes, NDArray[Axes]]] = None,
+        axes: Optional[Union[Axes, AxesArray]] = None,
         show_gradient: Optional[bool] = False,
         gradient_kwargs: dict[str, Any] = {  # noqa: B006
             "color": "black",
@@ -817,7 +824,7 @@ class _BaseCluster(Cluster, ChannelsMixin, ContainsMixin, MontageMixin):
     def _predict_raw(
         self,
         raw: BaseRaw,
-        picks_data: NDArray[int],
+        picks_data: ScalarIntArray,
         factor: int,
         tol: Union[int, float],
         half_window_size: int,
@@ -882,7 +889,7 @@ class _BaseCluster(Cluster, ChannelsMixin, ContainsMixin, MontageMixin):
     def _predict_epochs(
         self,
         epochs: BaseEpochs,
-        picks_data: NDArray[int],
+        picks_data: ScalarIntArray,
         factor: int,
         tol: Union[int, float],
         half_window_size: int,
@@ -930,12 +937,12 @@ class _BaseCluster(Cluster, ChannelsMixin, ContainsMixin, MontageMixin):
     # --------------------------------------------------------------------
     @staticmethod
     def _segment(
-        data: NDArray[float],
-        states: NDArray[float],
+        data: ScalarFloatArray,
+        states: ScalarFloatArray,
         factor: int,
         tol: Union[int, float],
         half_window_size: int,
-    ) -> NDArray[int]:
+    ) -> ScalarIntArray:
         """Create segmentation. Must operate on a copy of states."""
         data -= np.mean(data, axis=0)
         std = np.std(data, axis=0)
@@ -956,13 +963,13 @@ class _BaseCluster(Cluster, ChannelsMixin, ContainsMixin, MontageMixin):
 
     @staticmethod
     def _smooth_segmentation(
-        data: NDArray[float],
-        states: NDArray[float],
-        labels: NDArray[int],
+        data: ScalarFloatArray,
+        states: ScalarFloatArray,
+        labels: ScalarIntArray,
         factor: int,
         tol: Union[int, float],
         half_window_size: int,
-    ) -> NDArray[int]:
+    ) -> ScalarIntArray:
         """Apply smoothing.
 
         Adapted from [1].
@@ -1010,10 +1017,10 @@ class _BaseCluster(Cluster, ChannelsMixin, ContainsMixin, MontageMixin):
 
     @staticmethod
     def _reject_short_segments(
-        segmentation: NDArray[int],
-        data: NDArray[float],
+        segmentation: ScalarIntArray,
+        data: ScalarFloatArray,
         min_segment_length: int,
-    ) -> NDArray[int]:
+    ) -> ScalarIntArray:
         """Reject segments that are too short.
 
         Reject segments that are too short by replacing the labels with the adjacent
@@ -1082,7 +1089,7 @@ class _BaseCluster(Cluster, ChannelsMixin, ContainsMixin, MontageMixin):
         return segmentation
 
     @staticmethod
-    def _reject_edge_segments(segmentation: NDArray[int]) -> NDArray[int]:
+    def _reject_edge_segments(segmentation: ScalarIntArray) -> ScalarIntArray:
         """Set the first and last segment as unlabeled (0)."""
         # set first segment to unlabeled
         n = (segmentation != segmentation[0]).argmax()
@@ -1145,7 +1152,7 @@ class _BaseCluster(Cluster, ChannelsMixin, ContainsMixin, MontageMixin):
             self._fitted = False
 
     @property
-    def cluster_centers_(self) -> NDArray[float]:
+    def cluster_centers_(self) -> ScalarFloatArray:
         """Fitted clusters (the microstates maps).
 
         Returns None if cluster algorithm has not been fitted.
@@ -1159,7 +1166,7 @@ class _BaseCluster(Cluster, ChannelsMixin, ContainsMixin, MontageMixin):
         return self._cluster_centers_.copy()
 
     @property
-    def fitted_data(self) -> NDArray[float]:
+    def fitted_data(self) -> ScalarFloatArray:
         """Data array used to fit the clustering algorithm.
 
         :type: `~numpy.array` of shape (n_channels, n_samples) | None
@@ -1171,7 +1178,7 @@ class _BaseCluster(Cluster, ChannelsMixin, ContainsMixin, MontageMixin):
         return self._fitted_data.copy()
 
     @property
-    def labels_(self) -> NDArray[int]:
+    def labels_(self) -> ScalarIntArray:
         """Microstate label attributed to each sample of the fitted data.
 
         :type: `~numpy.array` of shape (n_samples, ) | None

--- a/pycrostates/cluster/aahc.py
+++ b/pycrostates/cluster/aahc.py
@@ -6,9 +6,8 @@ from typing import Any, Optional, Union
 import numpy as np
 from mne import BaseEpochs
 from mne.io import BaseRaw
-from numpy.typing import NDArray
 
-from .._typing import Picks
+from .._typing import Picks, ScalarFloatArray, ScalarIntArray
 from ..utils import _corr_vectors
 from ..utils._checks import _check_type
 from ..utils._docs import copy_doc, fill_doc
@@ -179,11 +178,11 @@ class AAHCluster(_BaseCluster):
     # --------------------------------------------------------------------
     @staticmethod
     def _aahc(
-        data: NDArray[float],
+        data: ScalarFloatArray,
         n_clusters: int,
         ignore_polarity: bool,
         normalize_input: bool,
-    ) -> tuple[float, NDArray[float], NDArray[int]]:
+    ) -> tuple[float, ScalarFloatArray, ScalarIntArray]:
         """Run the AAHC algorithm."""
         gfp_sum_sq = np.sum(data**2)
         maps, segmentation = AAHCluster._compute_maps(
@@ -196,11 +195,11 @@ class AAHCluster(_BaseCluster):
     # pylint: disable=too-many-locals
     @staticmethod
     def _compute_maps(
-        data: NDArray[float],
+        data: ScalarFloatArray,
         n_clusters: int,
         ignore_polarity: bool,
         normalize_input: bool,
-    ) -> tuple[NDArray[float], NDArray[int]]:
+    ) -> tuple[ScalarFloatArray, ScalarIntArray]:
         """Compute microstates maps."""
         n_chan, n_frame = data.shape
 

--- a/pycrostates/cluster/kmeans.py
+++ b/pycrostates/cluster/kmeans.py
@@ -8,9 +8,8 @@ from mne import BaseEpochs
 from mne.io import BaseRaw
 from mne.parallel import parallel_func
 from numpy.random import Generator, RandomState
-from numpy.typing import NDArray
 
-from .._typing import CHData, Picks, RANDomState
+from .._typing import CHData, Picks, RANDomState, ScalarFloatArray, ScalarIntArray
 from ..utils import _corr_vectors
 from ..utils._checks import _check_n_jobs, _check_random_state, _check_type
 from ..utils._docs import copy_doc, fill_doc
@@ -258,12 +257,12 @@ class ModKMeans(_BaseCluster):
     # --------------------------------------------------------------------
     @staticmethod
     def _kmeans(
-        data: NDArray[float],
+        data: ScalarFloatArray,
         n_clusters: int,
         max_iter: int,
         random_state: Union[RandomState, Generator],
         tol: Union[int, float],
-    ) -> tuple[float, NDArray[float], NDArray[int], bool]:
+    ) -> tuple[float, ScalarFloatArray, ScalarIntArray, bool]:
         """Run the k-means algorithm."""
         gfp_sum_sq = np.sum(data**2)
         maps, converged = ModKMeans._compute_maps(
@@ -277,12 +276,12 @@ class ModKMeans(_BaseCluster):
 
     @staticmethod
     def _compute_maps(
-        data: NDArray[float],
+        data: ScalarFloatArray,
         n_clusters: int,
         max_iter: int,
         random_state: Union[RandomState, Generator],
         tol: Union[int, float],
-    ) -> tuple[NDArray[float], bool]:
+    ) -> tuple[ScalarFloatArray, bool]:
         """Compute microstates maps.
 
         Based on mne_microstates by Marijn van Vliet <w.m.vanvliet@gmail.com>

--- a/pycrostates/cluster/kmeans.py
+++ b/pycrostates/cluster/kmeans.py
@@ -20,7 +20,7 @@ from ._base import _BaseCluster
 if TYPE_CHECKING:
     from typing import Any, Optional, Union
 
-    from .._typing import Picks, RANDomState, ScalarFloatArray, ScalarIntArray
+    from .._typing import Picks, RandomState, ScalarFloatArray, ScalarIntArray
     from ..io import ChData
 
 
@@ -56,7 +56,7 @@ class ModKMeans(_BaseCluster):
         n_init: int = 100,
         max_iter: int = 300,
         tol: Union[int, float] = 1e-6,
-        random_state: RANDomState = None,
+        random_state: RandomState = None,
     ):
         super().__init__()
 

--- a/pycrostates/cluster/kmeans.py
+++ b/pycrostates/cluster/kmeans.py
@@ -1,20 +1,26 @@
 """Class and functions to use modified Kmeans."""
 
-from pathlib import Path
-from typing import Any, Optional, Union
+from __future__ import annotations  # c.f. PEP 563, PEP 649
 
-import numpy as np
+from pathlib import Path
+from typing import TYPE_CHECKING
+
 from mne import BaseEpochs
 from mne.io import BaseRaw
 from mne.parallel import parallel_func
 from numpy.random import Generator, RandomState
 
-from .._typing import CHData, Picks, RANDomState, ScalarFloatArray, ScalarIntArray
 from ..utils import _corr_vectors
 from ..utils._checks import _check_n_jobs, _check_random_state, _check_type
 from ..utils._docs import copy_doc, fill_doc
 from ..utils._logs import logger
 from ._base import _BaseCluster
+
+if TYPE_CHECKING:
+    from typing import Any, Optional, Union
+
+    from .._typing import Picks, RANDomState, ScalarFloatArray, ScalarIntArray
+    from ..io import ChData
 
 
 @fill_doc
@@ -135,7 +141,7 @@ class ModKMeans(_BaseCluster):
     @fill_doc
     def fit(
         self,
-        inst: Union[BaseRaw, BaseEpochs, CHData],
+        inst: Union[BaseRaw, BaseEpochs, ChData],
         picks: Picks = "eeg",
         tmin: Optional[Union[int, float]] = None,
         tmax: Optional[Union[int, float]] = None,

--- a/pycrostates/cluster/kmeans.py
+++ b/pycrostates/cluster/kmeans.py
@@ -5,6 +5,7 @@ from __future__ import annotations  # c.f. PEP 563, PEP 649
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import numpy as np
 from mne import BaseEpochs
 from mne.io import BaseRaw
 from mne.parallel import parallel_func

--- a/pycrostates/cluster/utils/utils.py
+++ b/pycrostates/cluster/utils/utils.py
@@ -1,15 +1,14 @@
 import numpy as np
 import scipy
-from numpy.typing import NDArray
 
-from ..._typing import Cluster
+from ..._typing import Cluster, ScalarFloatArray
 from ...utils._checks import _check_type
 from ...utils._docs import fill_doc
 
 
 def _optimize_order(
-    centers: NDArray[float],
-    template_centers: NDArray[float],
+    centers: ScalarFloatArray,
+    template_centers: ScalarFloatArray,
     ignore_polarity: bool = True,
 ):
     n_states = len(centers)

--- a/pycrostates/cluster/utils/utils.py
+++ b/pycrostates/cluster/utils/utils.py
@@ -1,9 +1,16 @@
+from __future__ import annotations  # c.f. PEP 563, PEP 649
+
+from typing import TYPE_CHECKING
+
 import numpy as np
 import scipy
 
-from ..._typing import Cluster, ScalarFloatArray
 from ...utils._checks import _check_type
 from ...utils._docs import fill_doc
+
+if TYPE_CHECKING:
+    from ..._typing import ScalarFloatArray
+    from .._base import _BaseCluster
 
 
 def _optimize_order(
@@ -20,7 +27,7 @@ def _optimize_order(
 
 
 @fill_doc
-def optimize_order(inst: Cluster, template_inst: Cluster):
+def optimize_order(inst: _BaseCluster, template_inst: _BaseCluster):
     """Optimize the order of cluster centers between two cluster instances.
 
     Optimize the order of cluster centers in an instance of a clustering algorithm to

--- a/pycrostates/io/ch_data.py
+++ b/pycrostates/io/ch_data.py
@@ -12,13 +12,13 @@ if check_version("mne", "1.6"):
 else:
     from mne.io.pick import _picks_to_idx
 
-from .._typing import CHData, CHInfo, ScalarFloatArray
+from .._typing import CHInfo, ScalarFloatArray
 from ..utils._checks import _check_type
 from ..utils._docs import fill_doc
 from ..utils.mixin import ChannelsMixin, ContainsMixin, MontageMixin
 
 
-class ChData(CHData, ChannelsMixin, ContainsMixin, MontageMixin):
+class ChData(ChannelsMixin, ContainsMixin, MontageMixin):
     """ChData stores atemporal data with its spatial information.
 
     `~pycrostates.io.ChData` is similar to a raw instance where temporality has been

--- a/pycrostates/io/ch_data.py
+++ b/pycrostates/io/ch_data.py
@@ -14,7 +14,6 @@ if check_version("mne", "1.6"):
 else:
     from mne.io.pick import _picks_to_idx
 
-from .._typing import ScalarFloatArray
 from ..utils._checks import _check_type
 from ..utils._docs import fill_doc
 from ..utils.mixin import ChannelsMixin, ContainsMixin, MontageMixin

--- a/pycrostates/io/ch_data.py
+++ b/pycrostates/io/ch_data.py
@@ -6,14 +6,13 @@ from typing import Any, Union
 import numpy as np
 from mne import Info, pick_info
 from mne.utils import check_version
-from numpy.typing import NDArray
 
 if check_version("mne", "1.6"):
     from mne._fiff.pick import _picks_to_idx
 else:
     from mne.io.pick import _picks_to_idx
 
-from .._typing import CHData, CHInfo
+from .._typing import CHData, CHInfo, ScalarFloatArray
 from ..utils._checks import _check_type
 from ..utils._docs import fill_doc
 from ..utils.mixin import ChannelsMixin, ContainsMixin, MontageMixin
@@ -35,7 +34,7 @@ class ChData(CHData, ChannelsMixin, ContainsMixin, MontageMixin):
         to a `~pycrostates.io.ChInfo`.
     """
 
-    def __init__(self, data: NDArray[float], info: Union[Info, CHInfo]):
+    def __init__(self, data: ScalarFloatArray, info: Union[Info, CHInfo]):
         from .meas_info import ChInfo
 
         _check_type(data, (np.ndarray,), "data")
@@ -99,7 +98,7 @@ class ChData(CHData, ChannelsMixin, ContainsMixin, MontageMixin):
         return copy(self)
 
     @fill_doc
-    def get_data(self, picks=None) -> NDArray[float]:
+    def get_data(self, picks=None) -> ScalarFloatArray:
         """Retrieve the data array.
 
         Parameters

--- a/pycrostates/io/ch_data.py
+++ b/pycrostates/io/ch_data.py
@@ -1,7 +1,9 @@
 """Class to handle no temporal but spatial data."""
 
+from __future__ import annotations  # c.f. PEP 563, PEP 649
+
 from copy import copy, deepcopy
-from typing import Any, Union
+from typing import TYPE_CHECKING
 
 import numpy as np
 from mne import Info, pick_info
@@ -12,10 +14,16 @@ if check_version("mne", "1.6"):
 else:
     from mne.io.pick import _picks_to_idx
 
-from .._typing import CHInfo, ScalarFloatArray
+from .._typing import ScalarFloatArray
 from ..utils._checks import _check_type
 from ..utils._docs import fill_doc
 from ..utils.mixin import ChannelsMixin, ContainsMixin, MontageMixin
+
+if TYPE_CHECKING:
+    from typing import Any, Union
+
+    from .._typing import ScalarFloatArray
+    from . import ChInfo
 
 
 class ChData(ChannelsMixin, ContainsMixin, MontageMixin):
@@ -34,8 +42,8 @@ class ChData(ChannelsMixin, ContainsMixin, MontageMixin):
         to a `~pycrostates.io.ChInfo`.
     """
 
-    def __init__(self, data: ScalarFloatArray, info: Union[Info, CHInfo]):
-        from .meas_info import ChInfo
+    def __init__(self, data: ScalarFloatArray, info: Union[Info, ChInfo]):
+        from . import ChInfo
 
         _check_type(data, (np.ndarray,), "data")
         _check_type(info, (Info, ChInfo), "info")
@@ -162,7 +170,7 @@ class ChData(ChannelsMixin, ContainsMixin, MontageMixin):
 
     # --------------------------------------------------------------------
     @property
-    def info(self) -> CHInfo:
+    def info(self) -> ChInfo:
         """Atemporal measurement information.
 
         :type: ChInfo

--- a/pycrostates/io/fiff.py
+++ b/pycrostates/io/fiff.py
@@ -56,7 +56,6 @@ else:
         write_string,
     )
 
-from .._typing import ScalarFloatArray, ScalarIntArray
 from .._version import __version__
 from ..cluster import AAHCluster, ModKMeans
 from ..utils._checks import _check_type, _check_value
@@ -66,6 +65,7 @@ from ..utils._logs import logger
 if TYPE_CHECKING:
     from typing import Union
 
+    from .._typing import ScalarFloatArray, ScalarIntArray
     from . import ChInfo
 
 # ----------------------------------------------------------------------------

--- a/pycrostates/io/fiff.py
+++ b/pycrostates/io/fiff.py
@@ -12,7 +12,6 @@ from mne import Info, Transform
 from mne.io.constants import FIFF
 from mne.transforms import invert_transform
 from mne.utils import check_version
-from numpy.typing import NDArray
 
 if check_version("mne", "1.6"):
     from mne._fiff._digitization import _format_dig_points, _read_dig_fif
@@ -55,7 +54,7 @@ else:
         write_string,
     )
 
-from .._typing import CHInfo
+from .._typing import CHInfo, ScalarFloatArray, ScalarIntArray
 from .._version import __version__
 from ..cluster import AAHCluster, ModKMeans
 from ..utils._checks import _check_type, _check_value
@@ -95,12 +94,12 @@ FIFF_MNE_ICA_MISC_PARAMS -> fit variables (ending with '_')
 @fill_doc
 def _write_cluster(
     fname: Union[str, Path],
-    cluster_centers_: NDArray[float],
+    cluster_centers_: ScalarFloatArray,
     chinfo: Union[CHInfo, Info],
     algorithm: str,
     cluster_names: list[str],
-    fitted_data: NDArray[float],
-    labels_: NDArray[int],
+    fitted_data: ScalarFloatArray,
+    labels_: ScalarIntArray,
     **kwargs,
 ):
     """Save clustering solution to disk.
@@ -396,11 +395,11 @@ def _check_fit_parameters_and_variables(
 
 
 def _create_ModKMeans(
-    cluster_centers_: NDArray[float],
+    cluster_centers_: ScalarFloatArray,
     info: CHInfo,
     cluster_names: list[str],
-    fitted_data: NDArray[float],
-    labels_: NDArray[int],
+    fitted_data: ScalarFloatArray,
+    labels_: ScalarIntArray,
     n_init: int,
     max_iter: int,
     tol: Union[int, float],
@@ -421,11 +420,11 @@ def _create_ModKMeans(
 
 
 def _create_AAHCluster(
-    cluster_centers_: NDArray[float],
+    cluster_centers_: ScalarFloatArray,
     info: CHInfo,
     cluster_names: list[str],
-    fitted_data: NDArray[float],
-    labels_: NDArray[int],
+    fitted_data: ScalarFloatArray,
+    labels_: ScalarIntArray,
     ignore_polarity: bool,  # pylint: disable=unused-argument
     normalize_input: bool,
     GEV_: float,

--- a/pycrostates/io/fiff.py
+++ b/pycrostates/io/fiff.py
@@ -1,11 +1,13 @@
 """Contains I/O operation from and towards .fif format (MEGIN / MNE)."""
 
+from __future__ import annotations  # c.f. PEP 563, PEP 649
+
 import json
 import operator
 from functools import reduce
 from numbers import Integral
 from pathlib import Path
-from typing import Union
+from typing import TYPE_CHECKING
 
 import numpy as np
 from mne import Info, Transform
@@ -54,12 +56,17 @@ else:
         write_string,
     )
 
-from .._typing import CHInfo, ScalarFloatArray, ScalarIntArray
+from .._typing import ScalarFloatArray, ScalarIntArray
 from .._version import __version__
 from ..cluster import AAHCluster, ModKMeans
 from ..utils._checks import _check_type, _check_value
 from ..utils._docs import fill_doc
 from ..utils._logs import logger
+
+if TYPE_CHECKING:
+    from typing import Union
+
+    from . import ChInfo
 
 # ----------------------------------------------------------------------------
 """
@@ -95,7 +102,7 @@ FIFF_MNE_ICA_MISC_PARAMS -> fit variables (ending with '_')
 def _write_cluster(
     fname: Union[str, Path],
     cluster_centers_: ScalarFloatArray,
-    chinfo: Union[CHInfo, Info],
+    chinfo: Union[ChInfo, Info],
     algorithm: str,
     cluster_names: list[str],
     fitted_data: ScalarFloatArray,
@@ -396,7 +403,7 @@ def _check_fit_parameters_and_variables(
 
 def _create_ModKMeans(
     cluster_centers_: ScalarFloatArray,
-    info: CHInfo,
+    info: ChInfo,
     cluster_names: list[str],
     fitted_data: ScalarFloatArray,
     labels_: ScalarIntArray,
@@ -421,7 +428,7 @@ def _create_ModKMeans(
 
 def _create_AAHCluster(
     cluster_centers_: ScalarFloatArray,
-    info: CHInfo,
+    info: ChInfo,
     cluster_names: list[str],
     fitted_data: ScalarFloatArray,
     labels_: ScalarIntArray,
@@ -449,7 +456,7 @@ def _create_AAHCluster(
 
 
 # ----------------------------------------------------------------------------
-def _write_meas_info(fid, info: CHInfo):
+def _write_meas_info(fid, info: ChInfo):
     """Write measurement info into a file id (from a fif file).
 
     Parameters

--- a/pycrostates/io/meas_info.py
+++ b/pycrostates/io/meas_info.py
@@ -21,12 +21,11 @@ else:
     from mne.io.pick import get_channel_type_constants
     from mne.io.tag import _ch_coord_dict
 
-from .._typing import CHInfo
 from ..utils._checks import _check_type, _IntLike
 from ..utils._logs import logger
 
 
-class ChInfo(CHInfo, Info):
+class ChInfo(Info):
     """Atemporal measurement information.
 
     Similar to a :class:`mne.Info` class, but without any temporal information.

--- a/pycrostates/preprocessing/extract_gfp_peaks.py
+++ b/pycrostates/preprocessing/extract_gfp_peaks.py
@@ -1,6 +1,8 @@
 """Preprocessing functions to extract gfp peaks."""
 
-from typing import Optional, Union
+from __future__ import annotations  # c.f. PEP 563, PEP 649
+
+from typing import TYPE_CHECKING
 
 import numpy as np
 from mne import BaseEpochs, pick_info
@@ -13,7 +15,6 @@ if check_version("mne", "1.6"):
 else:
     from mne.io.pick import _picks_to_idx
 
-from .._typing import CHData, Picks, ScalarFloatArray
 from ..utils._checks import (
     _check_picks_uniqueness,
     _check_reject_by_annotation,
@@ -22,6 +23,12 @@ from ..utils._checks import (
 )
 from ..utils._docs import fill_doc
 from ..utils._logs import logger, verbose
+
+if TYPE_CHECKING:
+    from typing import Optional, Union
+
+    from .._typing import Picks, ScalarFloatArray
+    from ..io import ChData
 
 
 @fill_doc
@@ -35,7 +42,7 @@ def extract_gfp_peaks(
     tmax: Optional[float] = None,
     reject_by_annotation: bool = True,
     verbose=None,
-) -> CHData:
+) -> ChData:
     """:term:`Global Field Power` (:term:`GFP`) peaks extraction.
 
     Extract :term:`Global Field Power` (:term:`GFP`) peaks from :class:`~mne.Epochs` or

--- a/pycrostates/preprocessing/extract_gfp_peaks.py
+++ b/pycrostates/preprocessing/extract_gfp_peaks.py
@@ -6,7 +6,6 @@ import numpy as np
 from mne import BaseEpochs, pick_info
 from mne.io import BaseRaw
 from mne.utils import check_version
-from numpy.typing import NDArray
 from scipy.signal import find_peaks
 
 if check_version("mne", "1.6"):
@@ -14,7 +13,7 @@ if check_version("mne", "1.6"):
 else:
     from mne.io.pick import _picks_to_idx
 
-from .._typing import CHData, Picks
+from .._typing import CHData, Picks, ScalarFloatArray
 from ..utils._checks import (
     _check_picks_uniqueness,
     _check_reject_by_annotation,
@@ -140,8 +139,8 @@ def extract_gfp_peaks(
 
 
 def _extract_gfp_peaks(
-    data: NDArray[float], min_peak_distance: int = 2
-) -> NDArray[float]:
+    data: ScalarFloatArray, min_peak_distance: int = 2
+) -> ScalarFloatArray:
     """Extract GFP peaks from input data.
 
     Parameters

--- a/pycrostates/preprocessing/resample.py
+++ b/pycrostates/preprocessing/resample.py
@@ -26,7 +26,7 @@ from ..utils._logs import logger, verbose
 if TYPE_CHECKING:
     from typing import Optional, Union
 
-    from .._typing import Picks, RANDomState
+    from .._typing import Picks, RandomState
     from ..io import ChData
 
 
@@ -42,7 +42,7 @@ def resample(
     n_samples: int = None,
     coverage: float = None,
     replace: bool = True,
-    random_state: RANDomState = None,
+    random_state: RandomState = None,
     verbose=None,
 ) -> list[ChData]:
     """Resample a recording into epochs of random samples.

--- a/pycrostates/preprocessing/resample.py
+++ b/pycrostates/preprocessing/resample.py
@@ -1,6 +1,8 @@
 """Preprocessing functions to create resamples from raw or epochs instances."""
 
-from typing import Optional, Union
+from __future__ import annotations  # c.f. PEP 563, PEP 649
+
+from typing import TYPE_CHECKING
 
 import numpy as np
 from mne import BaseEpochs, pick_info
@@ -12,7 +14,6 @@ if check_version("mne", "1.6"):
 else:
     from mne.io.pick import _picks_to_idx
 
-from .._typing import CHData, Picks, RANDomState
 from ..utils._checks import (
     _check_random_state,
     _check_reject_by_annotation,
@@ -22,11 +23,17 @@ from ..utils._checks import (
 from ..utils._docs import fill_doc
 from ..utils._logs import logger, verbose
 
+if TYPE_CHECKING:
+    from typing import Optional, Union
+
+    from .._typing import Picks, RANDomState
+    from ..io import ChData
+
 
 @fill_doc
 @verbose
 def resample(
-    inst: Union[BaseRaw, BaseEpochs, CHData],
+    inst: Union[BaseRaw, BaseEpochs, ChData],
     picks: Picks = None,
     tmin: Optional[float] = None,
     tmax: Optional[float] = None,
@@ -37,7 +44,7 @@ def resample(
     replace: bool = True,
     random_state: RANDomState = None,
     verbose=None,
-) -> list[CHData]:
+) -> list[ChData]:
     """Resample a recording into epochs of random samples.
 
     Resample :class:`~mne.io.Raw`. :class:`~mne.Epochs` or

--- a/pycrostates/preprocessing/spatial_filter.py
+++ b/pycrostates/preprocessing/spatial_filter.py
@@ -18,7 +18,6 @@ if check_version("mne", "1.6"):
 else:
     from mne.io.pick import _picks_by_type
 
-from .._typing import ScalarFloatArray
 from ..utils._checks import _check_n_jobs, _check_type, _check_value
 from ..utils._docs import fill_doc
 from ..utils._logs import logger, verbose
@@ -26,6 +25,7 @@ from ..utils._logs import logger, verbose
 if TYPE_CHECKING:
     from typing import Union
 
+    from .._typing import ScalarFloatArray
     from ..io import ChData
 
 

--- a/pycrostates/preprocessing/spatial_filter.py
+++ b/pycrostates/preprocessing/spatial_filter.py
@@ -1,4 +1,6 @@
-from typing import Union
+from __future__ import annotations  # c.f. PEP 563, PEP 649
+
+from typing import TYPE_CHECKING
 
 import numpy as np
 from mne import BaseEpochs, pick_info
@@ -16,10 +18,15 @@ if check_version("mne", "1.6"):
 else:
     from mne.io.pick import _picks_by_type
 
-from .._typing import CHData, ScalarFloatArray
+from .._typing import ScalarFloatArray
 from ..utils._checks import _check_n_jobs, _check_type, _check_value
 from ..utils._docs import fill_doc
 from ..utils._logs import logger, verbose
+
+if TYPE_CHECKING:
+    from typing import Union
+
+    from ..io import ChData
 
 
 def _check_adjacency(adjacency, info, ch_type):
@@ -59,7 +66,7 @@ def _check_adjacency(adjacency, info, ch_type):
 @fill_doc
 @verbose
 def apply_spatial_filter(
-    inst: Union[BaseRaw, BaseEpochs, CHData],
+    inst: Union[BaseRaw, BaseEpochs, ChData],
     ch_type: str = "eeg",
     exclude_bads: bool = True,
     origin: Union[str, ScalarFloatArray] = "auto",
@@ -121,7 +128,9 @@ def apply_spatial_filter(
     ----------
     .. footbibliography::
     """  # noqa: E501
-    _check_type(inst, (BaseRaw, BaseEpochs, CHData), item_name="inst")
+    from ..io import ChData
+
+    _check_type(inst, (BaseRaw, BaseEpochs, ChData), item_name="inst")
     _check_type(ch_type, (str,), item_name="ch_type")
     _check_value(ch_type, ("eeg",), item_name="ch_type")
     _check_type(exclude_bads, (bool,), item_name="exclude_bads")

--- a/pycrostates/preprocessing/spatial_filter.py
+++ b/pycrostates/preprocessing/spatial_filter.py
@@ -9,7 +9,6 @@ from mne.io import BaseRaw
 from mne.parallel import parallel_func
 from mne.utils import check_version
 from mne.utils.check import _check_preload
-from numpy.typing import NDArray
 from scipy.sparse import csr_matrix
 
 if check_version("mne", "1.6"):
@@ -17,7 +16,7 @@ if check_version("mne", "1.6"):
 else:
     from mne.io.pick import _picks_by_type
 
-from .._typing import CHData
+from .._typing import CHData, ScalarFloatArray
 from ..utils._checks import _check_n_jobs, _check_type, _check_value
 from ..utils._docs import fill_doc
 from ..utils._logs import logger, verbose
@@ -63,7 +62,7 @@ def apply_spatial_filter(
     inst: Union[BaseRaw, BaseEpochs, CHData],
     ch_type: str = "eeg",
     exclude_bads: bool = True,
-    origin: Union[str, NDArray[float]] = "auto",
+    origin: Union[str, ScalarFloatArray] = "auto",
     adjacency: Union[csr_matrix, str] = "auto",
     n_jobs: int = 1,
     verbose=None,

--- a/pycrostates/segmentation/_base.py
+++ b/pycrostates/segmentation/_base.py
@@ -9,9 +9,8 @@ from matplotlib.axes import Axes
 from mne import BaseEpochs
 from mne.io import BaseRaw
 from mne.utils import check_version
-from numpy.typing import NDArray
 
-from .._typing import Segmentation
+from .._typing import ScalarFloatArray, ScalarIntArray, Segmentation
 from ..utils import _corr_vectors
 from ..utils._checks import _check_type
 from ..utils._docs import fill_doc
@@ -39,9 +38,9 @@ class _BaseSegmentation(Segmentation):
     @abstractmethod
     def __init__(
         self,
-        labels: NDArray[int],
+        labels: ScalarIntArray,
         inst: Union[BaseRaw, BaseEpochs],
-        cluster_centers_: NDArray[float],
+        cluster_centers_: ScalarFloatArray,
         cluster_names: Optional[list[str]] = None,
         predict_parameters: Optional[dict] = None,
     ):
@@ -303,7 +302,7 @@ class _BaseSegmentation(Segmentation):
     @fill_doc
     def plot_cluster_centers(
         self,
-        axes: Optional[Union[Axes, NDArray[Axes]]] = None,
+        axes: Optional[Union[Axes,]] = None,
         *,
         block: bool = False,
         show: Optional[bool] = None,
@@ -334,7 +333,7 @@ class _BaseSegmentation(Segmentation):
     @staticmethod
     def _check_cluster_names(
         cluster_names: list[str],
-        cluster_centers_: NDArray[float],
+        cluster_centers_: ScalarFloatArray,
     ):
         """Check that the argument 'cluster_names' is valid."""
         _check_type(cluster_names, (list, None), "cluster_names")
@@ -392,7 +391,7 @@ class _BaseSegmentation(Segmentation):
         return self._predict_parameters.copy()
 
     @property
-    def labels(self) -> NDArray[int]:
+    def labels(self) -> ScalarIntArray:
         """Microstate label attributed to each sample (the segmentation).
 
         :type: `~numpy.array`
@@ -400,9 +399,8 @@ class _BaseSegmentation(Segmentation):
         return self._labels.copy()
 
     @property
-    def cluster_centers_(self) -> NDArray[float]:
-        """Cluster centers (i.e topographies)
-        used to compute the segmentation.
+    def cluster_centers_(self) -> ScalarFloatArray:
+        """Cluster centers (i.e topographies) used to compute the segmentation.
 
         :type: `~numpy.array`
         """

--- a/pycrostates/segmentation/_base.py
+++ b/pycrostates/segmentation/_base.py
@@ -1,8 +1,10 @@
 """Segmentation module for segmented data."""
 
+from __future__ import annotations  # c.f. PEP 563, PEP 649
+
 import itertools
-from abc import abstractmethod
-from typing import Optional, Union
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
 import numpy as np
 from matplotlib.axes import Axes
@@ -10,7 +12,6 @@ from mne import BaseEpochs
 from mne.io import BaseRaw
 from mne.utils import check_version
 
-from .._typing import ScalarFloatArray, ScalarIntArray, Segmentation
 from ..utils import _corr_vectors
 from ..utils._checks import _check_type
 from ..utils._docs import fill_doc
@@ -19,9 +20,14 @@ from ..viz import plot_cluster_centers
 from .entropy import entropy
 from .transitions import _compute_expected_transition_matrix, _compute_transition_matrix
 
+if TYPE_CHECKING:
+    from typing import Optional, Union
+
+    from .._typing import ScalarFloatArray, ScalarIntArray
+
 
 @fill_doc
-class _BaseSegmentation(Segmentation):
+class _BaseSegmentation(ABC):
     """Base class for a Microstates segmentation.
 
     Parameters

--- a/pycrostates/segmentation/entropy.py
+++ b/pycrostates/segmentation/entropy.py
@@ -15,12 +15,12 @@ from mne.parallel import parallel_func
 
 from ..utils._checks import _check_n_jobs, _check_type, _check_value, _ensure_int
 from ..utils._docs import fill_doc
-from ._base import _BaseSegmentation
 
 if TYPE_CHECKING:
     from typing import Optional, Union
 
     from .._typing import ScalarFloatArray, ScalarIntArray
+    from ._base import _BaseSegmentation
 
 
 def _check_log_base(log_base) -> float:
@@ -118,6 +118,8 @@ def _check_labels(labels, item_name: str = "labels") -> None:
 def _check_segmentation(
     segmentation, item_name: str = "segmentation"
 ) -> ScalarIntArray:
+    from ._base import _BaseSegmentation
+
     _check_type(segmentation, (_BaseSegmentation,), item_name)
     return segmentation._labels.reshape(-1)  # reshape if epochs (returns a view)
 

--- a/pycrostates/segmentation/entropy.py
+++ b/pycrostates/segmentation/entropy.py
@@ -11,9 +11,8 @@ from typing import Optional, Union
 import numpy as np
 import scipy.stats
 from mne.parallel import parallel_func
-from numpy.typing import NDArray
 
-from .._typing import Segmentation
+from .._typing import ScalarFloatArray, ScalarIntArray, Segmentation
 from ..utils._checks import _check_n_jobs, _check_type, _check_value, _ensure_int
 from ..utils._docs import fill_doc
 
@@ -37,7 +36,7 @@ def _check_log_base(log_base) -> float:
     return log_base
 
 
-def _check_lags(lags) -> NDArray[int]:
+def _check_lags(lags) -> ScalarIntArray:
     _check_type(lags, ("int", "array-like"), "lags")
     if isinstance(lags, int):
         if lags < 1:
@@ -56,8 +55,8 @@ def _check_lags(lags) -> NDArray[int]:
 
 @fill_doc
 def _joint_entropy(
-    x: NDArray[int],
-    y: NDArray[int],
+    x: ScalarIntArray,
+    y: ScalarIntArray,
     state_to_ignore: Optional[int] = -1,
     log_base: Union[float, str] = 2,
 ) -> float:
@@ -110,14 +109,16 @@ def _check_labels(labels, item_name: str = "labels") -> None:
         raise ValueError(f"{item_name} must be an array of integers.")
 
 
-def _check_segmentation(segmentation, item_name: str = "segmentation") -> NDArray[int]:
+def _check_segmentation(
+    segmentation, item_name: str = "segmentation"
+) -> ScalarIntArray:
     _check_type(segmentation, (Segmentation,), item_name)
     return segmentation._labels.reshape(-1)  # reshape if epochs (returns a view)
 
 
 @fill_doc
 def _joint_entropy_history(
-    labels: NDArray[int],
+    labels: ScalarIntArray,
     k: int,
     state_to_ignore: Optional[int] = -1,
     log_base: Union[float, str] = 2,
@@ -163,7 +164,7 @@ def _joint_entropy_history(
 
 @fill_doc
 def _entropy(
-    labels: NDArray[int],
+    labels: ScalarIntArray,
     state_to_ignore: Optional[int] = -1,
     log_base: Union[float, str] = 2,
 ) -> float:
@@ -227,12 +228,12 @@ def entropy(
 # -- excess entropy rate ---------------------------------------------------------------
 @fill_doc
 def _excess_entropy_rate(
-    labels: NDArray[int],
+    labels: ScalarIntArray,
     history_length: int,
     state_to_ignore: Optional[int] = -1,
     log_base: Union[float, str] = 2,
     n_jobs: int = 1,
-) -> tuple[float, float, float, NDArray[int], NDArray[float]]:
+) -> tuple[float, float, float, ScalarIntArray, ScalarFloatArray]:
     """Estimate the entropy rate and the excess_entropy from a linear fit.
 
     Parameters
@@ -278,7 +279,7 @@ def excess_entropy_rate(
     ignore_repetitions: bool = False,
     log_base: Union[float, str] = 2,
     n_jobs: int = 1,
-) -> tuple[float, float, float, NDArray[int], NDArray[float]]:
+) -> tuple[float, float, float, ScalarIntArray, ScalarFloatArray]:
     r"""Estimate the entropy rate and the ``excess_entropy`` of the segmentation.
 
     The entropy rate and the ``excess_entropy`` are estimated from a linear fit:
@@ -334,7 +335,7 @@ def excess_entropy_rate(
 
 @fill_doc
 def _auto_information(
-    labels: NDArray[int],
+    labels: ScalarIntArray,
     k: int,
     state_to_ignore: Optional[int] = -1,
     log_base: Union[float, str] = 2,
@@ -384,12 +385,12 @@ def auto_information_function(
         int,
         list[int],
         tuple[int, ...],
-        NDArray[int],
+        ScalarIntArray,
     ],
     ignore_repetitions: bool = False,
     log_base: Union[float, str] = 2,
     n_jobs: int = 1,
-) -> tuple[NDArray[int], NDArray[float]]:
+) -> tuple[ScalarIntArray, ScalarFloatArray]:
     r"""Compute the Auto-information function (aif).
 
     Compute the Auto-information function (aif) as described
@@ -439,7 +440,7 @@ def auto_information_function(
 
 @fill_doc
 def _partial_auto_information(
-    labels: NDArray[int],
+    labels: ScalarIntArray,
     k: int,
     state_to_ignore: Optional[int] = -1,
     log_base: Union[float, str] = 2,
@@ -495,12 +496,12 @@ def partial_auto_information_function(
         int,
         list[int],
         tuple[int, ...],
-        NDArray[int],
+        ScalarIntArray,
     ],
     ignore_repetitions: bool = False,
     log_base: Union[float, str] = 2,
     n_jobs: Optional[int] = 1,
-) -> tuple[NDArray[int], NDArray[float]]:
+) -> tuple[ScalarIntArray, ScalarFloatArray]:
     r"""Compute the Partial auto-information function.
 
     Compute the Partial auto-information function as described

--- a/pycrostates/segmentation/entropy.py
+++ b/pycrostates/segmentation/entropy.py
@@ -7,6 +7,7 @@ Front Physiol (2018) https://doi.org/10.3389/fphys.2018.01382
 
 from __future__ import annotations  # c.f. PEP 563, PEP 649
 
+import itertools
 from typing import TYPE_CHECKING
 
 import numpy as np

--- a/pycrostates/segmentation/entropy.py
+++ b/pycrostates/segmentation/entropy.py
@@ -5,16 +5,22 @@ F. von Wegner, Partial Autoinformation to Characterize Symbolic Sequences
 Front Physiol (2018) https://doi.org/10.3389/fphys.2018.01382
 """
 
-import itertools
-from typing import Optional, Union
+from __future__ import annotations  # c.f. PEP 563, PEP 649
+
+from typing import TYPE_CHECKING
 
 import numpy as np
 import scipy.stats
 from mne.parallel import parallel_func
 
-from .._typing import ScalarFloatArray, ScalarIntArray, Segmentation
 from ..utils._checks import _check_n_jobs, _check_type, _check_value, _ensure_int
 from ..utils._docs import fill_doc
+from ._base import _BaseSegmentation
+
+if TYPE_CHECKING:
+    from typing import Optional, Union
+
+    from .._typing import ScalarFloatArray, ScalarIntArray
 
 
 def _check_log_base(log_base) -> float:
@@ -112,7 +118,7 @@ def _check_labels(labels, item_name: str = "labels") -> None:
 def _check_segmentation(
     segmentation, item_name: str = "segmentation"
 ) -> ScalarIntArray:
-    _check_type(segmentation, (Segmentation,), item_name)
+    _check_type(segmentation, (_BaseSegmentation,), item_name)
     return segmentation._labels.reshape(-1)  # reshape if epochs (returns a view)
 
 
@@ -193,7 +199,7 @@ def _entropy(
 
 @fill_doc
 def entropy(
-    segmentation: Segmentation,
+    segmentation: _BaseSegmentation,
     ignore_repetitions: bool = False,
     log_base: Union[float, str] = 2,
 ) -> float:
@@ -274,7 +280,7 @@ def _excess_entropy_rate(
 
 @fill_doc
 def excess_entropy_rate(
-    segmentation: Segmentation,
+    segmentation: _BaseSegmentation,
     history_length: int,
     ignore_repetitions: bool = False,
     log_base: Union[float, str] = 2,
@@ -380,7 +386,7 @@ def _auto_information(
 
 @fill_doc
 def auto_information_function(
-    segmentation: Segmentation,
+    segmentation: _BaseSegmentation,
     lags: Union[
         int,
         list[int],
@@ -491,7 +497,7 @@ def _partial_auto_information(
 
 @fill_doc
 def partial_auto_information_function(
-    segmentation: Segmentation,
+    segmentation: _BaseSegmentation,
     lags: Union[
         int,
         list[int],

--- a/pycrostates/segmentation/transitions.py
+++ b/pycrostates/segmentation/transitions.py
@@ -1,19 +1,19 @@
 from itertools import groupby
 
 import numpy as np
-from numpy.typing import NDArray
 
+from .._typing import ScalarFloatArray, ScalarIntArray
 from ..utils._checks import _check_type, _check_value
 from ..utils._docs import fill_doc
 
 
 @fill_doc
 def compute_transition_matrix(
-    labels: NDArray[int],
+    labels: ScalarIntArray,
     n_clusters: int,
     stat: str = "probability",
     ignore_repetitions: bool = True,
-) -> NDArray[float]:
+) -> ScalarFloatArray:
     """Compute the observed transition matrix.
 
     Count the number of transitions from one state to another and aggregate the result
@@ -40,11 +40,11 @@ def compute_transition_matrix(
 
 
 def _compute_transition_matrix(
-    labels: NDArray[int],
+    labels: ScalarIntArray,
     n_clusters: int,
     stat: str = "probability",
     ignore_repetitions: bool = True,
-) -> NDArray[float]:
+) -> ScalarFloatArray:
     """Compute observed transition."""
     # common error checking
     _check_value(stat, ("count", "probability", "proportion", "percent"), "stat")
@@ -76,11 +76,11 @@ def _compute_transition_matrix(
 
 @fill_doc
 def compute_expected_transition_matrix(
-    labels: NDArray[int],
+    labels: ScalarIntArray,
     n_clusters: int,
     stat: str = "probability",
     ignore_repetitions: bool = True,
-) -> NDArray[float]:
+) -> ScalarFloatArray:
     """Compute the expected transition matrix.
 
     Compute the theoretical transition matrix as if time course was ignored, but
@@ -111,11 +111,11 @@ def compute_expected_transition_matrix(
 
 
 def _compute_expected_transition_matrix(
-    labels: NDArray[int],
+    labels: ScalarIntArray,
     n_clusters: int,
     stat: str = "probability",
     ignore_repetitions: bool = True,
-) -> NDArray[float]:
+) -> ScalarFloatArray:
     """Compute theoretical transition matrix.
 
     The theoretical transition matrix takes into account the time coverage.
@@ -156,7 +156,7 @@ def _compute_expected_transition_matrix(
 
 
 def _check_labels_n_clusters(
-    labels: NDArray[int],
+    labels: ScalarIntArray,
     n_clusters: int,
 ) -> None:
     """Checker for labels and n_clusters."""

--- a/pycrostates/segmentation/transitions.py
+++ b/pycrostates/segmentation/transitions.py
@@ -1,10 +1,14 @@
-from itertools import groupby
+from __future__ import annotations  # c.f. PEP 563, PEP 649
+
+from typing import TYPE_CHECKING
 
 import numpy as np
 
-from .._typing import ScalarFloatArray, ScalarIntArray
 from ..utils._checks import _check_type, _check_value
 from ..utils._docs import fill_doc
+
+if TYPE_CHECKING:
+    from .._typing import ScalarFloatArray, ScalarIntArray
 
 
 @fill_doc

--- a/pycrostates/segmentation/transitions.py
+++ b/pycrostates/segmentation/transitions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations  # c.f. PEP 563, PEP 649
 
+from itertools import groupby
 from typing import TYPE_CHECKING
 
 import numpy as np

--- a/pycrostates/viz/cluster_centers.py
+++ b/pycrostates/viz/cluster_centers.py
@@ -1,6 +1,8 @@
 """Visualization module for plotting cluster centers."""
 
-from typing import Any, Optional, Union
+from __future__ import annotations  # c.f. PEP 563, PEP 649
+
+from typing import TYPE_CHECKING
 
 import numpy as np
 from matplotlib import pyplot as plt
@@ -9,10 +11,17 @@ from mne import Info
 from mne.channels.layout import _find_topomap_coords
 from mne.viz import plot_topomap
 
-from .._typing import AxesArray, CHInfo, ScalarFloatArray
+from .._typing import AxesArray, ScalarFloatArray
 from ..utils._checks import _check_axes, _check_type, _ensure_valid_show
 from ..utils._docs import fill_doc
 from ..utils._logs import logger, verbose
+
+if TYPE_CHECKING:
+    from typing import Any, Optional, Union
+
+    from .._typing import AxesArray, ScalarFloatArray
+    from ..io import ChInfo
+
 
 _GRADIENT_KWARGS_DEFAULTS: dict[str, str] = {
     "color": "black",
@@ -25,7 +34,7 @@ _GRADIENT_KWARGS_DEFAULTS: dict[str, str] = {
 @verbose
 def plot_cluster_centers(
     cluster_centers: ScalarFloatArray,
-    info: Union[Info, CHInfo],
+    info: Union[Info, ChInfo],
     cluster_names: list[str] = None,
     axes: Optional[Union[Axes, AxesArray]] = None,
     show_gradient: Optional[bool] = False,

--- a/pycrostates/viz/cluster_centers.py
+++ b/pycrostates/viz/cluster_centers.py
@@ -8,9 +8,8 @@ from matplotlib.axes import Axes
 from mne import Info
 from mne.channels.layout import _find_topomap_coords
 from mne.viz import plot_topomap
-from numpy.typing import NDArray
 
-from .._typing import CHInfo
+from .._typing import AxesArray, CHInfo, ScalarFloatArray
 from ..utils._checks import _check_axes, _check_type, _ensure_valid_show
 from ..utils._docs import fill_doc
 from ..utils._logs import logger, verbose
@@ -25,10 +24,10 @@ _GRADIENT_KWARGS_DEFAULTS: dict[str, str] = {
 @fill_doc
 @verbose
 def plot_cluster_centers(
-    cluster_centers: NDArray[float],
+    cluster_centers: ScalarFloatArray,
     info: Union[Info, CHInfo],
     cluster_names: list[str] = None,
-    axes: Optional[Union[Axes, NDArray[Axes]]] = None,
+    axes: Optional[Union[Axes, AxesArray]] = None,
     show_gradient: Optional[bool] = False,
     gradient_kwargs: dict[str, Any] = _GRADIENT_KWARGS_DEFAULTS,
     *,

--- a/pycrostates/viz/cluster_centers.py
+++ b/pycrostates/viz/cluster_centers.py
@@ -11,7 +11,6 @@ from mne import Info
 from mne.channels.layout import _find_topomap_coords
 from mne.viz import plot_topomap
 
-from .._typing import AxesArray, ScalarFloatArray
 from ..utils._checks import _check_axes, _check_type, _ensure_valid_show
 from ..utils._docs import fill_doc
 from ..utils._logs import logger, verbose

--- a/pycrostates/viz/segmentation.py
+++ b/pycrostates/viz/segmentation.py
@@ -1,6 +1,8 @@
 """Visualisation module for plotting segmentations."""
 
-from typing import Optional, Union
+from __future__ import annotations  # c.f. PEP 563, PEP 649
+
+from typing import TYPE_CHECKING
 
 import numpy as np
 from matplotlib import colormaps, colors
@@ -10,10 +12,14 @@ from mne import BaseEpochs
 from mne.io import BaseRaw
 from mne.utils import check_version
 
-from .._typing import ScalarFloatArray, ScalarIntArray
 from ..utils._checks import _check_type, _ensure_valid_show
 from ..utils._docs import fill_doc
 from ..utils._logs import logger, verbose
+
+if TYPE_CHECKING:
+    from typing import Optional, Union
+
+    from .._typing import ScalarFloatArray, ScalarIntArray
 
 
 @fill_doc

--- a/pycrostates/viz/segmentation.py
+++ b/pycrostates/viz/segmentation.py
@@ -9,8 +9,8 @@ from matplotlib.axes import Axes
 from mne import BaseEpochs
 from mne.io import BaseRaw
 from mne.utils import check_version
-from numpy.typing import NDArray
 
+from .._typing import ScalarFloatArray, ScalarIntArray
 from ..utils._checks import _check_type, _ensure_valid_show
 from ..utils._docs import fill_doc
 from ..utils._logs import logger, verbose
@@ -18,7 +18,7 @@ from ..utils._logs import logger, verbose
 
 @fill_doc
 def plot_raw_segmentation(
-    labels: NDArray[int],
+    labels: ScalarIntArray,
     raw: BaseRaw,
     n_clusters: int,
     cluster_names: list[str] = None,
@@ -107,7 +107,7 @@ def plot_raw_segmentation(
 
 @fill_doc
 def plot_epoch_segmentation(
-    labels: NDArray[int],
+    labels: ScalarIntArray,
     epochs: BaseEpochs,
     n_clusters: int,
     cluster_names: list[str] = None,
@@ -202,9 +202,9 @@ def plot_epoch_segmentation(
 
 @verbose
 def _plot_segmentation(
-    labels: NDArray[int],
-    gfp: NDArray[float],
-    times: NDArray[float],
+    labels: ScalarIntArray,
+    gfp: ScalarFloatArray,
+    times: ScalarFloatArray,
     n_clusters: int,
     cluster_names: list[str] = None,
     cmap: Optional[Union[str, colors.Colormap]] = None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,7 +146,7 @@ py_version = 39
 add_ignore = 'D100,D104,D107'
 convention = 'numpy'
 ignore-decorators = '(copy_doc|property|.*setter|.*getter|pyqtSlot|Slot)'
-match = '^(?!setup|__init__|test_).*\.py'
+match = '^(?!setup|__init__|test_|_typing).*\.py'
 match-dir = '^pycrostates.*'
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
This PR fix some type-hints issues:
- Pylance warnings in VSCode because of the invalid definition for `NDArray`
- Removes our custom type-hints `Cluster`, `Segmentation`, `CHInfo`, `CHData` in favor of using the `TYPE_CHECKING` variable and `from __future__ import annotations` to fix the circular imports

Test green locally. It's just a maintenance PR ;)